### PR TITLE
Use elf_rawdata() in ELF copying

### DIFF
--- a/src/elf-utils.c
+++ b/src/elf-utils.c
@@ -29,7 +29,7 @@ int elf_utils_copy(Elf *dest, Elf *source)
 		ELF_ASSERT(gelf_update_shdr(dst_scn, &shdr));
 
 		src_data = NULL;
-		while ((src_data = elf_getdata(src_scn, src_data)) != NULL) {
+		while ((src_data = elf_rawdata(src_scn, src_data)) != NULL) {
 			ELF_ASSERT(dst_data = elf_newdata(dst_scn));
 			memcpy(dst_data, src_data, sizeof(Elf_Data));
 		}


### PR DESCRIPTION
Do not translate data section when copying from ELF to the SCE ELF. Should fix https://github.com/vitasdk/vita-toolchain/issues/6