### PR TITLE
Improved CMake scripts for libzip

### DIFF
--- a/cmake/Modules/Findlibzip.cmake
+++ b/cmake/Modules/Findlibzip.cmake
@@ -4,11 +4,14 @@ pkg_check_modules(PC_libzip libzip>=1.1.3)
 find_path(libzip_INCLUDE_DIR zip.h
           HINTS ${PC_libzip_INCLUDEDIR} ${PC_libzip_INCLUDE_DIRS})
 
+find_path(libzip_CONFIG_INCLUDE_DIR zipconf.h
+          HINTS ${PC_libzip_INCLUDEDIR} ${PC_libzip_INCLUDE_DIRS})
+
 find_library(libzip_LIBRARY NAMES zip
              HINTS ${PC_libzip_LIBDIR} ${PC_libzip_LIBRARY_DIRS} )
 
 set(libzip_LIBRARIES ${libzip_LIBRARY})
-set(libzip_INCLUDE_DIRS ${libzip_INCLUDE_DIR})
+set(libzip_INCLUDE_DIRS ${libzip_INCLUDE_DIR} ${libzip_CONFIG_INCLUDE_DIR})
 
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(libzip DEFAULT_MSG

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -14,6 +14,10 @@ if(USE_BUNDLED_ENDIAN_H)
 	add_definitions(-DUSE_BUNDLED_ENDIAN_H)
 endif()
 
+if(DEFINED ZIP_STATIC)
+	add_definitions(-DZIP_STATIC)
+endif()
+
 if(DEFINED DEFAULT_JSON)
 	add_definitions(-DDEFAULT_JSON="${DEFAULT_JSON}")
 endif()


### PR DESCRIPTION
libzip keeps its configuration header in "lib/libzip/include", this is picked up fine by cmake, but our cmake script neglects adding it to the include dirs.
ZIP_STATIC must be defined for windows builds when using a static version of libzip.