### PR TITLE
Fix all warnings

### DIFF
--- a/src/vita-elf-create.c
+++ b/src/vita-elf-create.c
@@ -249,6 +249,11 @@ int main(int argc, char *argv[])
 	if (!(imports = load_imports(&args, &imports_count)))
 		return EXIT_FAILURE;
 
+	if (imports_count == 0){
+		TRACEF(VERBOSE, "Unable to load JSON database\n");
+		return EXIT_FAILURE;
+	}
+
 	if (!vita_elf_lookup_imports(ve, imports, imports_count))
 		status = EXIT_FAILURE;
 


### PR DESCRIPTION
As signalled by @Ryp in #18

```-Wall -Wextra``` give us come interesting information (invalid assert call, invalid comparison)
Maybe we should enable them by default ?