### PR TITLE
Remove db.json requirement on vita-elf-create

### DIFF
--- a/src/sce-elf.c
+++ b/src/sce-elf.c
@@ -928,7 +928,7 @@ int sce_elf_rewrite_stubs(Elf *dest, const vita_elf_t *ve)
 	size_t shstrndx;
 	void *shstrtab;
 	uint32_t *stubdata;
-	int i,j;
+	int j;
 	int *cur_ndx;
 	char *stub_name, *aux_name;
 
@@ -942,16 +942,8 @@ int sce_elf_rewrite_stubs(Elf *dest, const vita_elf_t *ve)
 		ELF_ASSERT(scn = elf_getscn(dest, *cur_ndx));
 		ELF_ASSERT(gelf_getshdr(scn, &shdr));
 		
-		stub_name = shstrtab + shdr.sh_name;
-		for(i=strlen(stub_name)-1;i>=0;i--){
-			if(stub_name[i]=='.'){
-				stub_name=&stub_name[i];
-				break;
-			}
-		}
-		
-		aux_name = calloc(strlen(stub_name),sizeof(char));
-		strcpy(aux_name,stub_name);
+		stub_name = strrchr(shstrtab + shdr.sh_name,'.');
+		aux_name = strdup(stub_name);
 		strcpy(shstrtab + shdr.sh_name, ".text.fstubs");
 		strcat(shstrtab + shdr.sh_name, aux_name);
 		free(aux_name);
@@ -979,16 +971,8 @@ int sce_elf_rewrite_stubs(Elf *dest, const vita_elf_t *ve)
 		ELF_ASSERT(scn = elf_getscn(dest, *cur_ndx));
 		ELF_ASSERT(gelf_getshdr(scn, &shdr));
 		
-		stub_name = shstrtab + shdr.sh_name;
-		for(i=strlen(stub_name)-1;i>=0;i--){
-			if(stub_name[i]=='.'){
-				stub_name=&stub_name[i];
-				break;
-			}
-		}
-		
-		aux_name = calloc(strlen(stub_name),sizeof(char));
-		strcpy(aux_name,stub_name);
+		stub_name = strrchr(shstrtab + shdr.sh_name,'.');
+		aux_name = strdup(stub_name);
 		strcpy(shstrtab + shdr.sh_name, ".data.vstubs");
 		strcat(shstrtab + shdr.sh_name, stub_name);
 		free(aux_name);

--- a/src/sce-elf.c
+++ b/src/sce-elf.c
@@ -711,7 +711,6 @@ int sce_elf_write_module_info(
 	ehdr.e_entry = ((segndx & 0x3) << 30) | start_segoffset;
 	ELF_ASSERT(gelf_update_ehdr(dest, &ehdr));
 
-
 	for (i = 0; i < sizeof(sce_section_sizes_t) / sizeof(Elf32_Word); i++) {
 		int scn_size = ((Elf32_Word *)sizes)[i];
 		if (scn_size == 0)
@@ -929,41 +928,77 @@ int sce_elf_rewrite_stubs(Elf *dest, const vita_elf_t *ve)
 	size_t shstrndx;
 	void *shstrtab;
 	uint32_t *stubdata;
+	int i,j;
+	int *cur_ndx;
+	char *stub_name, *aux_name;
 
 	ELF_ASSERT(elf_getshdrstrndx(dest, &shstrndx) == 0);
 	ELF_ASSERT(scn = elf_getscn(dest, shstrndx));
 	ELF_ASSERT(data = elf_getdata(scn, NULL));
 	shstrtab = data->d_buf;
 
-	ELF_ASSERT(scn = elf_getscn(dest, ve->fstubs_ndx));
-	ELF_ASSERT(gelf_getshdr(scn, &shdr));
-	strcpy(shstrtab + shdr.sh_name, ".text.fstubs");
-	data = NULL;
-	while ((data = elf_getdata(scn, data)) != NULL) {
-		for (stubdata = (uint32_t *)data->d_buf;
-				(void *)stubdata < data->d_buf + data->d_size - 11; stubdata += 4) {
-			stubdata[0] = htole32(sce_elf_stub_func[0]);
-			stubdata[1] = htole32(sce_elf_stub_func[1]);
-			stubdata[2] = htole32(sce_elf_stub_func[2]);
-			stubdata[3] = 0;
+	for(j=0;j<ve->fstubs_va.count;j++){
+		cur_ndx = VARRAY_ELEMENT(&ve->fstubs_va,j);
+		ELF_ASSERT(scn = elf_getscn(dest, *cur_ndx));
+		ELF_ASSERT(gelf_getshdr(scn, &shdr));
+		
+		stub_name = shstrtab + shdr.sh_name;
+		for(i=strlen(stub_name)-1;i>=0;i--){
+			if(stub_name[i]=='.'){
+				stub_name=&stub_name[i];
+				break;
+			}
+		}
+		
+		aux_name = calloc(strlen(stub_name),sizeof(char));
+		strcpy(aux_name,stub_name);
+		strcpy(shstrtab + shdr.sh_name, ".text.fstubs");
+		strcat(shstrtab + shdr.sh_name, aux_name);
+		free(aux_name);
+		
+		data = NULL;
+		while ((data = elf_getdata(scn, data)) != NULL) {
+			for (stubdata = (uint32_t *)data->d_buf;
+					(void *)stubdata < data->d_buf + data->d_size - 11; stubdata += 4) {
+				stubdata[0] = htole32(sce_elf_stub_func[0]);
+				stubdata[1] = htole32(sce_elf_stub_func[1]);
+				stubdata[2] = htole32(sce_elf_stub_func[2]);
+				stubdata[3] = 0;
+			}
 		}
 	}
 
-	ELF_ASSERT(scn = elf_getscn(dest, ve->vstubs_ndx));
 
 	/* If the section index is zero, it means that it's nonexistent */
-	if (ve->vstubs_ndx == 0) {
+	if (ve->vstubs_va.count == 0) {
 		return 1;
 	}
-
-	ELF_ASSERT(gelf_getshdr(scn, &shdr));
-	strcpy(shstrtab + shdr.sh_name, ".data.vstubs");
-
-	data = NULL;
-	while ((data = elf_getdata(scn, data)) != NULL) {
-		for (stubdata = (uint32_t *)data->d_buf;
-				(void *)stubdata < data->d_buf + data->d_size - 11; stubdata += 4) {
-			memset(stubdata, 0, 16);
+	
+	for(j=0;j<ve->vstubs_va.count;j++){
+		cur_ndx = VARRAY_ELEMENT(&ve->vstubs_va,j);
+		ELF_ASSERT(scn = elf_getscn(dest, *cur_ndx));
+		ELF_ASSERT(gelf_getshdr(scn, &shdr));
+		
+		stub_name = shstrtab + shdr.sh_name;
+		for(i=strlen(stub_name)-1;i>=0;i--){
+			if(stub_name[i]=='.'){
+				stub_name=&stub_name[i];
+				break;
+			}
+		}
+		
+		aux_name = calloc(strlen(stub_name),sizeof(char));
+		strcpy(aux_name,stub_name);
+		strcpy(shstrtab + shdr.sh_name, ".data.vstubs");
+		strcat(shstrtab + shdr.sh_name, stub_name);
+		free(aux_name);
+		
+		data = NULL;
+		while ((data = elf_getdata(scn, data)) != NULL) {
+			for (stubdata = (uint32_t *)data->d_buf;
+					(void *)stubdata < data->d_buf + data->d_size - 11; stubdata += 4) {
+				memset(stubdata, 0, 16);
+			}
 		}
 	}
 

--- a/src/vita-elf.c
+++ b/src/vita-elf.c
@@ -36,7 +36,7 @@ static int load_stubs(Elf_Scn *scn, int *num_stubs, vita_elf_stub_t **stubs, cha
 	GElf_Shdr shdr;
 	Elf_Data *data;
 	uint32_t *stub_data;
-	int i, chunk_offset, total_bytes;
+	int chunk_offset, total_bytes;
 	vita_elf_stub_t *curstub;
 
 	gelf_getshdr(scn, &shdr);
@@ -52,12 +52,7 @@ static int load_stubs(Elf_Scn *scn, int *num_stubs, vita_elf_stub_t **stubs, cha
 		*num_stubs = *num_stubs + (shdr.sh_size / 16);
 	}
 	
-	for(i=strlen(name)-1;i>=0;i--){
-		if(name[i]=='.'){
-			name=&name[i+1];
-			break;
-		}
-	}
+	name = strrchr(name,'.')+1;
 	
 	curstub = *stubs;
 	curstub = &curstub[*num_stubs - (shdr.sh_size / 16)];

--- a/src/vita-elf.c
+++ b/src/vita-elf.c
@@ -38,19 +38,14 @@ static int load_stubs(Elf_Scn *scn, int *num_stubs, vita_elf_stub_t **stubs, cha
 	uint32_t *stub_data;
 	int chunk_offset, total_bytes;
 	vita_elf_stub_t *curstub;
+	int old_num;
 
 	gelf_getshdr(scn, &shdr);
-  
-	if(*num_stubs==0){
-		*num_stubs = shdr.sh_size / 16;
-		*stubs = calloc(*num_stubs, sizeof(vita_elf_stub_t));
-	}else{
-		curstub = *stubs;
-		*stubs = calloc(*num_stubs + (shdr.sh_size / 16),sizeof(vita_elf_stub_t));
-		memcpy(*stubs,curstub,*num_stubs * sizeof(vita_elf_stub_t));
-		free(curstub);
-		*num_stubs = *num_stubs + (shdr.sh_size / 16);
-	}
+
+	old_num = *num_stubs;
+	*num_stubs = old_num + shdr.sh_size / 16;
+	*stubs = realloc(*stubs, *num_stubs * sizeof(vita_elf_stub_t));
+	memset(&(*stubs)[old_num], 0, sizeof(vita_elf_stub_t) * shdr.sh_size / 16);
 	
 	name = strrchr(name,'.')+1;
 	

--- a/src/vita-elf.c
+++ b/src/vita-elf.c
@@ -31,20 +31,37 @@
 
 static void free_rela_table(vita_elf_rela_table_t *rtable);
 
-static int load_stubs(Elf_Scn *scn, int *num_stubs, vita_elf_stub_t **stubs)
+static int load_stubs(Elf_Scn *scn, int *num_stubs, vita_elf_stub_t **stubs, char *name)
 {
 	GElf_Shdr shdr;
 	Elf_Data *data;
 	uint32_t *stub_data;
-	int chunk_offset, total_bytes;
+	int i, chunk_offset, total_bytes;
 	vita_elf_stub_t *curstub;
 
 	gelf_getshdr(scn, &shdr);
-
-	*num_stubs = shdr.sh_size / 16;
-	*stubs = calloc(*num_stubs, sizeof(vita_elf_stub_t));
-
+  
+	if(*num_stubs==0){
+		*num_stubs = shdr.sh_size / 16;
+		*stubs = calloc(*num_stubs, sizeof(vita_elf_stub_t));
+	}else{
+		curstub = *stubs;
+		*stubs = calloc(*num_stubs + (shdr.sh_size / 16),sizeof(vita_elf_stub_t));
+		memcpy(*stubs,curstub,*num_stubs * sizeof(vita_elf_stub_t));
+		free(curstub);
+		*num_stubs = *num_stubs + (shdr.sh_size / 16);
+	}
+	
+	for(i=strlen(name)-1;i>=0;i--){
+		if(name[i]=='.'){
+			name=&name[i+1];
+			break;
+		}
+	}
+	
 	curstub = *stubs;
+	curstub = &curstub[*num_stubs - (shdr.sh_size / 16)];
+	
 	data = NULL; total_bytes = 0;
 	while (total_bytes < shdr.sh_size &&
 			(data = elf_getdata(scn, data)) != NULL) {
@@ -54,6 +71,7 @@ static int load_stubs(Elf_Scn *scn, int *num_stubs, vita_elf_stub_t **stubs)
 				stub_data += 4, chunk_offset += 16) {
 			curstub->addr = shdr.sh_addr + data->d_off + chunk_offset;
 			curstub->library_nid = le32toh(stub_data[0]);
+			curstub->module = vita_imports_module_new(name,false,0,0,0);
 			curstub->module_nid = le32toh(stub_data[1]);
 			curstub->target_nid = le32toh(stub_data[2]);
 			curstub++;
@@ -292,11 +310,11 @@ static int load_rela_table(vita_elf_t *ve, Elf_Scn *scn)
 	return 0;
 }
 
-static int lookup_stub_symbols(vita_elf_t *ve, int num_stubs, vita_elf_stub_t *stubs, int stubs_ndx, int sym_type)
+static int lookup_stub_symbols(vita_elf_t *ve, int num_stubs, vita_elf_stub_t *stubs, varray *stubs_va, int sym_type)
 {
 	int symndx;
 	vita_elf_symbol_t *cursym;
-	int stub;
+	int stub, stubs_ndx, i, *cur_ndx;
 
 	for (symndx = 0; symndx < ve->num_symbols; symndx++) {
 		cursym = ve->symtab + symndx;
@@ -305,13 +323,23 @@ static int lookup_stub_symbols(vita_elf_t *ve, int num_stubs, vita_elf_stub_t *s
 			continue;
 		if (cursym->type != STT_FUNC && cursym->type != STT_OBJECT)
 			continue;
-		if (cursym->shndx != stubs_ndx)
-			continue;
-
+		stubs_ndx = -1;
+		
+		for(i=0;i<stubs_va->count;i++){
+			cur_ndx = VARRAY_ELEMENT(stubs_va,i);
+			if (cursym->shndx == *cur_ndx){
+				stubs_ndx = cursym->shndx;
+				break;
+			}
+		}
+		
+		if(stubs_ndx == -1)
+			continue;	
+			
 		if (cursym->type != sym_type)
 			FAILX("Global symbol %s in section %d expected to have type %s; instead has type %s",
 					cursym->name, stubs_ndx, elf_decode_st_type(sym_type), elf_decode_st_type(cursym->type));
-
+		
 		for (stub = 0; stub < num_stubs; stub++) {
 			if (stubs[stub].addr != cursym->value)
 				continue;
@@ -391,6 +419,9 @@ vita_elf_t *vita_elf_load(const char *filename, int check_stub_count)
 
 	ve = calloc(1, sizeof(vita_elf_t));
 	ASSERT(ve != NULL);
+	
+	ASSERT(varray_init(&ve->fstubs_va, sizeof(int), 8));
+	ASSERT(varray_init(&ve->vstubs_va, sizeof(int), 4));
 
 	if ((ve->file = fopen(filename, "rb")) == NULL)
 		FAIL("open %s failed", filename);
@@ -417,17 +448,15 @@ vita_elf_t *vita_elf_load(const char *filename, int check_stub_count)
 
 		ELF_ASSERT(name = elf_strptr(ve->elf, shstrndx, shdr.sh_name));
 
-		if (shdr.sh_type == SHT_PROGBITS && strcmp(name, ".vitalink.fstubs") == 0) {
-			if (ve->fstubs_ndx != 0)
-				FAILX("Multiple .vitalink.fstubs sections in binary");
-			ve->fstubs_ndx = elf_ndxscn(scn);
-			if (!load_stubs(scn, &ve->num_fstubs, &ve->fstubs))
+		if (shdr.sh_type == SHT_PROGBITS && strncmp(name, ".vitalink.fstubs", strlen(".vitalink.fstubs")) == 0) {
+			int ndxscn = elf_ndxscn(scn);
+			varray_push(&ve->fstubs_va,&ndxscn);
+			if (!load_stubs(scn, &ve->num_fstubs, &ve->fstubs, name))
 				goto failure;
-		} else if (shdr.sh_type == SHT_PROGBITS && strcmp(name, ".vitalink.vstubs") == 0) {
-			if (ve->vstubs_ndx != 0)
-				FAILX("Multiple .vitalink.vstubs sections in binary");
-			ve->vstubs_ndx = elf_ndxscn(scn);
-			if (!load_stubs(scn, &ve->num_vstubs, &ve->vstubs))
+		} else if (shdr.sh_type == SHT_PROGBITS && strncmp(name, ".vitalink.vstubs", strlen(".vitalink.vstubs")) == 0) {
+			int ndxscn = elf_ndxscn(scn);
+			varray_push(&ve->vstubs_va,&ndxscn);
+			if (!load_stubs(scn, &ve->num_vstubs, &ve->vstubs, name))
 				goto failure;
 		}
 
@@ -447,7 +476,7 @@ vita_elf_t *vita_elf_load(const char *filename, int check_stub_count)
 		}
 	}
 
-	if (ve->fstubs_ndx == 0 && ve->vstubs_ndx == 0 && check_stub_count)
+	if (ve->fstubs_va.count == 0 && ve->vstubs_va.count == 0 && check_stub_count)
 		FAILX("No .vitalink stub sections in binary, probably not a Vita binary. If this is a vita binary, pass '-n' to squash this error.");
 
 	if (ve->symtab == NULL)
@@ -456,12 +485,12 @@ vita_elf_t *vita_elf_load(const char *filename, int check_stub_count)
 	if (ve->rela_tables == NULL)
 		FAILX("No relocation sections in binary; use -Wl,-q while compiling");
 
-	if (ve->fstubs_ndx != 0) {
-		if (!lookup_stub_symbols(ve, ve->num_fstubs, ve->fstubs, ve->fstubs_ndx, STT_FUNC)) goto failure;
+	if (ve->fstubs_va.count != 0) {
+		if (!lookup_stub_symbols(ve, ve->num_fstubs, ve->fstubs, &ve->fstubs_va, STT_FUNC)) goto failure;
 	}
 
-	if (ve->vstubs_ndx != 0) {
-		if (!lookup_stub_symbols(ve, ve->num_vstubs, ve->vstubs, ve->vstubs_ndx, STT_OBJECT)) goto failure;
+	if (ve->vstubs_va.count != 0) {
+		if (!lookup_stub_symbols(ve, ve->num_vstubs, ve->vstubs, &ve->vstubs_va, STT_OBJECT)) goto failure;
 	}
 
 	ELF_ASSERT(elf_getphdrnum(ve->elf, &segment_count) == 0);
@@ -530,7 +559,7 @@ void vita_elf_free(vita_elf_t *ve)
 }
 
 typedef vita_imports_stub_t *(*find_stub_func_ptr)(vita_imports_module_t *, uint32_t);
-static int lookup_stubs(vita_elf_stub_t *stubs, int num_stubs, vita_imports_t **imports, int imports_count, find_stub_func_ptr find_stub, const char *stub_type_name)
+static int lookup_stubs(vita_elf_stub_t *stubs, int num_stubs, find_stub_func_ptr find_stub, const char *stub_type_name)
 {
 	int found_all = 1;
 	int i, j;
@@ -538,50 +567,18 @@ static int lookup_stubs(vita_elf_stub_t *stubs, int num_stubs, vita_imports_t **
 
 	for (i = 0; i < num_stubs; i++) {
 		stub = &(stubs[i]);
-
-		for (j = 0; j < imports_count; j++) {
-			stub->library = vita_imports_find_lib(imports[j], stub->library_nid);
-			if (stub->library != NULL) {
-				break;
-			}
-		}
-
-		if (stub->library == NULL) {
-			warnx("Unable to find library with NID %u for %s symbol %s",
-					stub->library_nid, stub_type_name,
-					stub->symbol ? stub->symbol->name : "(unreferenced stub)");
-			found_all = 0;
-			continue;
-		}
-
-		stub->module = vita_imports_find_module(stub->library, stub->module_nid);
-		if (stub->module == NULL) {
-			warnx("Unable to find module with NID %u for %s symbol %s",
-					stub->module_nid, stub_type_name,
-					stub->symbol ? stub->symbol->name : "(unreferenced stub)");
-			found_all = 0;
-			continue;
-		}
-
-		stub->target = find_stub(stub->module, stub->target_nid);
-		if (stub->target == NULL) {
-			warnx("Unable to find %s with NID %u for symbol %s",
-					stub_type_name, stub->module_nid,
-					stub->symbol ? stub->symbol->name : "(unreferenced stub)");
-			found_all = 0;
-		}
+		stub->target = vita_imports_stub_new(stub->symbol ? stub->symbol->name : "(unreferenced stub)", 0);
 	}
 
 	return found_all;
 }
 
-int vita_elf_lookup_imports(vita_elf_t *ve, vita_imports_t **imports, int imports_count)
+int vita_elf_lookup_imports(vita_elf_t *ve)
 {
 	int found_all = 1;
-
-	if (!lookup_stubs(ve->fstubs, ve->num_fstubs, imports, imports_count, &vita_imports_find_function, "function"))
+	if (!lookup_stubs(ve->fstubs, ve->num_fstubs, &vita_imports_find_function, "function"))
 		found_all = 0;
-	if (!lookup_stubs(ve->vstubs, ve->num_vstubs, imports, imports_count, &vita_imports_find_variable, "variable"))
+	if (!lookup_stubs(ve->vstubs, ve->num_vstubs, &vita_imports_find_variable, "variable"))
 		found_all = 0;
 
 	return found_all;

--- a/src/vita-elf.h
+++ b/src/vita-elf.h
@@ -6,6 +6,7 @@
 #include <stdint.h>
 
 #include "vita-import.h"
+#include "varray.h"
 
 /* Convenience representation of a symtab entry */
 typedef struct vita_elf_symbol_t {
@@ -62,8 +63,8 @@ typedef struct vita_elf_t {
 	int mode;
 	Elf *elf;
 
-	int fstubs_ndx;
-	int vstubs_ndx;
+	varray fstubs_va;
+	varray vstubs_va;
 
 	int symtab_ndx;
 	vita_elf_symbol_t *symtab;
@@ -83,7 +84,7 @@ typedef struct vita_elf_t {
 vita_elf_t *vita_elf_load(const char *filename, int check_stub_count);
 void vita_elf_free(vita_elf_t *ve);
 
-int vita_elf_lookup_imports(vita_elf_t *ve, vita_imports_t **imports, int imports_count);
+int vita_elf_lookup_imports(vita_elf_t *ve);
 
 const void *vita_elf_vaddr_to_host(const vita_elf_t *ve, Elf32_Addr vaddr);
 const void *vita_elf_segoffset_to_host(const vita_elf_t *ve, int segndx, uint32_t offset);

--- a/src/vita-libs-gen.c
+++ b/src/vita-libs-gen.c
@@ -89,7 +89,7 @@ int generate_assembly(vita_imports_t **imports, int imports_count)
 					if ((fp = fopen(filename, "w")) == NULL)
 						return 0;
 					fprintf(fp, ".arch armv7a\n\n");
-					fprintf(fp, ".section .vitalink.fstubs,\"ax\",%%progbits\n\n");
+					fprintf(fp, ".section .vitalink.fstubs.%s,\"ax\",%%progbits\n\n", module->name);
 					fprintf(fp,
 						"\t.align 4\n"
 						"\t.global %s\n"
@@ -114,7 +114,7 @@ int generate_assembly(vita_imports_t **imports, int imports_count)
 					if ((fp = fopen(filename, "w")) == NULL)
 						return 0;
 					fprintf(fp, ".arch armv7a\n\n");
-					fprintf(fp, ".section .vitalink.vstubs,\"aw\",%%progbits\n\n");
+					fprintf(fp, ".section .vitalink.vstubs.%s,\"aw\",%%progbits\n\n",module->name);
 					fprintf(fp,
 						"\t.align 4\n"
 						"\t.global %s\n"


### PR DESCRIPTION
Modified #69 to use a realloc and memset instead of a second malloc and a memcpy. This is the advice of the code review.