### PR TITLE
vita-libs-gen: Only generate one .S per module, change stubs naming s…

### DIFF
--- a/src/vita-libs-gen.c
+++ b/src/vita-libs-gen.c
@@ -256,6 +256,8 @@ int generate_makefile(vita_imports_t **imports, int imports_count)
 		"endef\n\n"
 		"$(foreach library,$(TARGETS),$(eval $(call LIBRARY_template,$(library))))\n\n"
 		"all: $(TARGETS)\n\n"
+		"install: $(TARGETS)\n"
+		"\tcp $(TARGETS) $(VITASDK)/arm-vita-eabi/lib\n\n"
 		"clean:\n"
 		"\trm -f $(TARGETS) $(ALL_OBJS)\n\n"
 		"$(TARGETS):\n"


### PR DESCRIPTION
…cheme

Stubs naming scheme:
    * User libs: libSceFoo_stub.a <- {SceFoo_SceBar0.o, SceFoo_SceBar1.o, ...}
    * Kernel libs: libSceFoo_kernel_stub.a <- {SceFoo_SceBar2.o, SceFoo_SceBar3.o, ...}