### PR TITLE
Fix segfault when rewriting section names in sce_elf_rewrite_stubs

### DIFF
--- a/src/sce-elf.c
+++ b/src/sce-elf.c
@@ -930,7 +930,7 @@ int sce_elf_rewrite_stubs(Elf *dest, const vita_elf_t *ve)
 	uint32_t *stubdata;
 	int j;
 	int *cur_ndx;
-	char *stub_name, *aux_name;
+	char *sh_name, *stub_name;
 
 	ELF_ASSERT(elf_getshdrstrndx(dest, &shstrndx) == 0);
 	ELF_ASSERT(scn = elf_getscn(dest, shstrndx));
@@ -942,11 +942,9 @@ int sce_elf_rewrite_stubs(Elf *dest, const vita_elf_t *ve)
 		ELF_ASSERT(scn = elf_getscn(dest, *cur_ndx));
 		ELF_ASSERT(gelf_getshdr(scn, &shdr));
 		
-		stub_name = strrchr(shstrtab + shdr.sh_name,'.');
-		aux_name = strdup(stub_name);
-		strcpy(shstrtab + shdr.sh_name, ".text.fstubs");
-		strcat(shstrtab + shdr.sh_name, aux_name);
-		free(aux_name);
+		sh_name = shstrtab + shdr.sh_name;
+		stub_name = strrchr(sh_name, '.');
+		snprintf(sh_name, strlen(sh_name) + 1, ".text.fstubs%s", stub_name);
 		
 		data = NULL;
 		while ((data = elf_getdata(scn, data)) != NULL) {
@@ -971,11 +969,9 @@ int sce_elf_rewrite_stubs(Elf *dest, const vita_elf_t *ve)
 		ELF_ASSERT(scn = elf_getscn(dest, *cur_ndx));
 		ELF_ASSERT(gelf_getshdr(scn, &shdr));
 		
-		stub_name = strrchr(shstrtab + shdr.sh_name,'.');
-		aux_name = strdup(stub_name);
-		strcpy(shstrtab + shdr.sh_name, ".data.vstubs");
-		strcat(shstrtab + shdr.sh_name, stub_name);
-		free(aux_name);
+		sh_name = shstrtab + shdr.sh_name;
+		stub_name = strrchr(sh_name, '.');
+		snprintf(sh_name, strlen(sh_name) + 1, ".data.vstubs%s", stub_name);
 		
 		data = NULL;
 		while ((data = elf_getdata(scn, data)) != NULL) {

--- a/src/sce-elf.c
+++ b/src/sce-elf.c
@@ -943,6 +943,8 @@ int sce_elf_rewrite_stubs(Elf *dest, const vita_elf_t *ve)
 		ELF_ASSERT(gelf_getshdr(scn, &shdr));
 		
 		sh_name = shstrtab + shdr.sh_name;
+		if (strstr(sh_name, ".vitalink.fstubs.") != sh_name)
+			errx(EXIT_FAILURE, "Your ELF file contains a malformed .vitalink.fstubs section. Please make sure all your stub libraries are up-to-date.");
 		stub_name = strrchr(sh_name, '.');
 		snprintf(sh_name, strlen(sh_name) + 1, ".text.fstubs%s", stub_name);
 		
@@ -970,6 +972,8 @@ int sce_elf_rewrite_stubs(Elf *dest, const vita_elf_t *ve)
 		ELF_ASSERT(gelf_getshdr(scn, &shdr));
 		
 		sh_name = shstrtab + shdr.sh_name;
+		if (strstr(sh_name, ".vitalink.vstubs.") != sh_name)
+			errx(EXIT_FAILURE, "Your ELF file contains a malformed .vitalink.vstubs section. Please make sure all your stub libraries are up-to-date.");
 		stub_name = strrchr(sh_name, '.');
 		snprintf(sh_name, strlen(sh_name) + 1, ".data.vstubs%s", stub_name);
 		


### PR DESCRIPTION
Fixes #72 

We're changing section names from `.vitalink.fstubs.SceWhatever` to `.text.fstubs.SceWhatever`. Since new name is always shorter than the old one, it was assumed a buffer overrun is not possible. However, it still can happen with malformed names, e.g. trying to change `.vitalink.fstubs` => `.text.fstubs.fstubs`. Before we would segfault, with this patch it will truncate the name to fit, since it's the best thing we can do against malformed section names (the resulting elf should work anyway).