### PR TITLE
vita.toolchain.cmake: Remove CMAKE_FIND_ROOT_PATH_MODE_PROGRAM ONLY

### DIFF
--- a/cmake_toolchain/vita.toolchain.cmake
+++ b/cmake_toolchain/vita.toolchain.cmake
@@ -109,6 +109,5 @@ set( CMAKE_FIND_ROOT_PATH "${VITASDK}/bin" "${VITASDK}/arm-vita-eabi" "${CMAKE_I
 set( CMAKE_INSTALL_PREFIX "${VITASDK}/arm-vita-eabi" CACHE PATH "default install path" )
 
 # only search for libraries and includes in vita toolchain
-set( CMAKE_FIND_ROOT_PATH_MODE_PROGRAM ONLY )
 set( CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY )
 set( CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY )


### PR DESCRIPTION
On newer cmake (as seen on 3.10.1), this results in it not finding `make`,
resulting in build errors on every homebrew.