### PR TITLE
vita-libs-gen: Use firmware field

### DIFF
--- a/src/vita-import.c
+++ b/src/vita-import.c
@@ -8,6 +8,10 @@ vita_imports_t *vita_imports_new(int n_libs)
 	if (imp == NULL)
 		return NULL;
 
+	imp->postfix = calloc(64, sizeof(char));
+
+	imp->firmware = NULL;
+
 	imp->n_libs = n_libs;
 
 	imp->libs = calloc(n_libs, sizeof(*imp->libs));
@@ -22,6 +26,11 @@ void vita_imports_free(vita_imports_t *imp)
 		for (i = 0; i < imp->n_libs; i++) {
 			vita_imports_lib_free(imp->libs[i]);
 		}
+
+		if (imp->firmware)
+			free(imp->firmware);
+
+		free(imp->postfix);
 		free(imp);
 	}
 }

--- a/src/vita-import.h
+++ b/src/vita-import.h
@@ -36,6 +36,8 @@ typedef struct {
 } vita_imports_lib_t;
 
 typedef struct {
+	char *firmware;
+	char *postfix;
 	vita_imports_lib_t **libs;
 	int n_libs;
 } vita_imports_t;


### PR DESCRIPTION
if filled `firmware` in the root and this value isn't `3.60`,
will attach postfix before `_stub.a`

eg;
pass to
```
firmware: 3.67
```
all generated libs will end with `_367_stub.a` like `libSceCpuForKernel_367_stub.a`

Related vitasdk/vita-headers#300