### PR TITLE
vita.cmake: avoid rebuilding unnecessarily vpk and eboot

### DIFF
--- a/cmake_toolchain/vita.cmake
+++ b/cmake_toolchain/vita.cmake
@@ -64,12 +64,12 @@ macro(vita_create_self target source)
     COMMENT "Converting to Sony ELF ${source}.velf" VERBATIM
   )
   separate_arguments(VITA_MAKE_FSELF_FLAGS)
-  add_custom_target(${target} ALL
+  add_custom_command(OUTPUT ${target}
     COMMAND ${VITA_MAKE_FSELF} ${VITA_MAKE_FSELF_FLAGS} ${source}.velf ${target}
     DEPENDS ${source}.velf
     COMMENT "Creating SELF ${target}"
   )
-  add_dependencies(${target} ${source})
+  add_custom_target(${target}_ ALL DEPENDS ${target})
 endmacro(vita_create_self)
 ##################################################
 
@@ -178,11 +178,11 @@ macro(vita_create_vpk target titleid eboot)
     COMMENT "Generating param.sfo for ${target}"
   )
   separate_arguments(VITA_PACK_VPK_FLAGS)
-  add_custom_target(${target} ALL
+  add_custom_command(OUTPUT ${target}
     COMMAND ${VITA_PACK_VPK} ${VITA_PACK_VPK_FLAGS} -s ${target}_param.sfo -b ${eboot} ${target}
-    DEPENDS ${target}_param.sfo
+    DEPENDS ${target}_param.sfo ${eboot}
     COMMENT "Building vpk ${target}"
   )
-  add_dependencies(${target} ${eboot})
+  add_custom_target(${target}_ ALL DEPENDS ${target})
 endmacro(vita_create_vpk)
 ##################################################


### PR DESCRIPTION
`add_custom_target` isn't suited for running command that output stuff.

The [documentation](https://cmake.org/cmake/help/latest/command/add_custom_target.html) states that

> The target has no output file and is always considered out of date even if the commands try to create a file with the name of the target.

So I kept the target only to force the vpk and eboot to be built by default, but it does not rebuild it if it is not necessary.