### PR TITLE
Allow overwriting of CMAKE_FIND_ROOT_PATH_MODE_LIBRARY & INCLUDE

### DIFF
--- a/cmake_toolchain/vita.toolchain.cmake
+++ b/cmake_toolchain/vita.toolchain.cmake
@@ -109,5 +109,9 @@ set( CMAKE_FIND_ROOT_PATH "${VITASDK}/bin" "${VITASDK}/arm-vita-eabi" "${CMAKE_I
 set( CMAKE_INSTALL_PREFIX "${VITASDK}/arm-vita-eabi" CACHE PATH "default install path" )
 
 # only search for libraries and includes in vita toolchain
-set( CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY )
-set( CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY )
+if( NOT CMAKE_FIND_ROOT_PATH_MODE_LIBRARY )
+  set( CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY )
+endif()
+if( NOT CMAKE_FIND_ROOT_PATH_MODE_INCLUDE )
+  set( CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY )
+endif()


### PR DESCRIPTION
This matches the behaviour of the Android toolchain cmake file [1] and it allows providing self-compiled libraries (not part of vitasdk/vdpm) as argued in this git issue [2].

[1] https://android.googlesource.com/platform/ndk/+/master/build/cmake/android.toolchain.cmake#281
[2] https://github.com/android-ndk/ndk/issues/517