### PR TITLE
vita.cmake: Rename custom target name

### DIFF
--- a/cmake_toolchain/vita.cmake
+++ b/cmake_toolchain/vita.cmake
@@ -69,7 +69,7 @@ macro(vita_create_self target source)
     DEPENDS ${source}.velf
     COMMENT "Creating SELF ${target}"
   )
-  add_custom_target(${target}_ ALL DEPENDS ${target})
+  add_custom_target(${target}.dep ALL DEPENDS ${target})
 endmacro(vita_create_self)
 ##################################################
 
@@ -184,6 +184,6 @@ macro(vita_create_vpk target titleid eboot)
     DEPENDS ${target}_param.sfo ${eboot} ${resources}
     COMMENT "Building vpk ${target}"
   )
-  add_custom_target(${target}_ ALL DEPENDS ${target})
+  add_custom_target(${target}.dep ALL DEPENDS ${target})
 endmacro(vita_create_vpk)
 ##################################################


### PR DESCRIPTION
this patch related PR #120.
basically this PR would be good to prevent the rebuild.
but some projects was broken.
we should use `add_dependencies(proj sub_proj_out_)` instead
`add_dependencies(proj sub_proj_out)`.
this changing is broken changes of the sdk.

this patch give the more clear name to custom target.
(`add_dependencies(proj sub_proj_out.dep)`)
but it'll give the broken change to end users once more.