### PR TITLE
Fix multiple definition of `sce_elf_stub_func'

### DIFF
--- a/src/sce-elf.h
+++ b/src/sce-elf.h
@@ -103,6 +103,4 @@ int sce_elf_rewrite_stubs(Elf *dest, const vita_elf_t *ve);
 
 int sce_elf_set_headers(FILE *outfile, const vita_elf_t *ve);
 
-const uint32_t sce_elf_stub_func[3];
-
 #endif


### PR DESCRIPTION
it occurs a compile-linking error with gcc 10.1