### PR TITLE
Update build.sh script and cmake chain for fixing libelf conflict

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,8 @@ cmake_minimum_required(VERSION 2.6)
 project(vita-toolchain)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/Modules/")
+set(ENV{PKG_CONFIG_PATH} "${CMAKE_SOURCE_DIR}/builds/deps_build/lib/pkgconfig")
+include_directories("${CMAKE_SOURCE_DIR}/builds/deps_build/include")
 
 add_subdirectory(src)
 add_subdirectory(cmake_toolchain)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,8 +2,11 @@ cmake_minimum_required(VERSION 2.6)
 project(vita-toolchain)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/Modules/")
-set(ENV{PKG_CONFIG_PATH} "${CMAKE_SOURCE_DIR}/builds/deps_build/lib/pkgconfig")
-include_directories("${CMAKE_SOURCE_DIR}/builds/deps_build/include")
+if (NOT TOOLCHAIN_DEPS_DIR)
+    set(TOOLCHAIN_DEPS_DIR "${CMAKE_SOURCE_DIR}/builds/deps_build")
+endif()
+set(ENV{PKG_CONFIG_PATH} "${TOOLCHAIN_DEPS_DIR}/lib/pkgconfig")
+include_directories("${TOOLCHAIN_DEPS_DIR}/include")
 
 add_subdirectory(src)
 add_subdirectory(cmake_toolchain)

--- a/build.sh
+++ b/build.sh
@@ -41,6 +41,7 @@ cd build
 cmake -G"Unix Makefiles" \
       -DCMAKE_C_FLAGS_RELEASE:STRING="-O3 -DNDEBUG -DZIP_STATIC" \
       -DCMAKE_BUILD_TYPE=Release \
+      -DTOOLCHAIN_DEPS_DIR=${DEPSDIR} \
       -DBUILD_SHARED_LIBS=`[ "$OS" = Windows_NT ] && echo ON || echo OFF` \
       ../
 cmake --build . --clean-first -- ${JOBS}

--- a/build.sh
+++ b/build.sh
@@ -36,7 +36,7 @@ cmake --build . --target libyaml_build -- ${JOBS}
 
 echo "[Step 2.0] Build vita-toolchain..."
 cd ${CWD}
-mkdir build
+mkdir -p build
 cd build
 cmake -G"Unix Makefiles" -DCMAKE_C_FLAGS_RELEASE:STRING="-O3 -DNDEBUG -DZIP_STATIC" -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=`[ "$OS" = Windows_NT ] && echo ON || echo OFF` -Dlibyaml_INCLUDE_DIRS=${DEPSDIR}/include/ -Dlibyaml_LIBRARY=${DEPSDIR}/lib/libyaml.a -Dlibelf_INCLUDE_DIR=${DEPSDIR}/include -Dlibelf_LIBRARY=${DEPSDIR}/lib/libelf.a -Dzlib_INCLUDE_DIR=${DEPSDIR}/include/ -Dzlib_LIBRARY=${DEPSDIR}/lib/libz.a -Dlibzip_INCLUDE_DIR=${DEPSDIR}/include/ -Dlibzip_CONFIG_INCLUDE_DIR=${DEPSDIR}/lib/libzip/include -Dlibzip_LIBRARY=${DEPSDIR}/lib/libzip.a  ../
-cmake --build . -- ${JOBS}
+cmake --build . --clean-first -- ${JOBS}

--- a/build.sh
+++ b/build.sh
@@ -38,5 +38,9 @@ echo "[Step 2.0] Build vita-toolchain..."
 cd ${CWD}
 mkdir -p build
 cd build
-cmake -G"Unix Makefiles" -DCMAKE_C_FLAGS_RELEASE:STRING="-O3 -DNDEBUG -DZIP_STATIC" -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=`[ "$OS" = Windows_NT ] && echo ON || echo OFF` -Dlibyaml_INCLUDE_DIRS=${DEPSDIR}/include/ -Dlibyaml_LIBRARY=${DEPSDIR}/lib/libyaml.a -Dlibelf_INCLUDE_DIR=${DEPSDIR}/include -Dlibelf_LIBRARY=${DEPSDIR}/lib/libelf.a -Dzlib_INCLUDE_DIR=${DEPSDIR}/include/ -Dzlib_LIBRARY=${DEPSDIR}/lib/libz.a -Dlibzip_INCLUDE_DIR=${DEPSDIR}/include/ -Dlibzip_CONFIG_INCLUDE_DIR=${DEPSDIR}/lib/libzip/include -Dlibzip_LIBRARY=${DEPSDIR}/lib/libzip.a  ../
+cmake -G"Unix Makefiles" \
+      -DCMAKE_C_FLAGS_RELEASE:STRING="-O3 -DNDEBUG -DZIP_STATIC" \
+      -DCMAKE_BUILD_TYPE=Release \
+      -DBUILD_SHARED_LIBS=`[ "$OS" = Windows_NT ] && echo ON || echo OFF` \
+      ../
 cmake --build . --clean-first -- ${JOBS}

--- a/build.sh
+++ b/build.sh
@@ -7,8 +7,15 @@ BUILDDIR=$PWD/builds
 DEPSDIR=$PWD/builds/deps_build
 JOBS=-j`getconf _NPROCESSORS_ONLN || sysctl kern.smp.cpus | sed 's/kern.smp.cpus: //'` || true
 
-echo "[Step 0.0] Clone buildscripts..."
-git clone https://github.com/vitasdk/buildscripts
+if [ ! -d buildscripts ]; then
+    echo "[Step 0.0] Clone buildscripts..."
+    git clone https://github.com/vitasdk/buildscripts
+else
+    echo "[Step 0.0] Update buildscripts..."
+    cd buildscripts
+    git fetch origin
+    git reset --hard origin/master
+fi
 
 echo "[Step 1.0] Prepare buildscripts..."
 mkdir -p ${BUILDDIR}

--- a/cmake/Modules/Findlibelf.cmake
+++ b/cmake/Modules/Findlibelf.cmake
@@ -1,5 +1,5 @@
 find_package(PkgConfig)
-pkg_check_modules(PC_libelf libelf=0.8.13)
+pkg_check_modules(PC_libelf REQUIRED libelf=0.8.13)
 
 find_path(libelf_INCLUDE_DIR libelf.h
           HINTS ${PC_libelf_INCLUDEDIR} ${PC_libelf_INCLUDE_DIRS})

--- a/cmake/Modules/Findlibyaml.cmake
+++ b/cmake/Modules/Findlibyaml.cmake
@@ -1,5 +1,5 @@
 find_package(PkgConfig)
-pkg_check_modules(PC_libyaml libyaml>=0.1.6)
+pkg_check_modules(PC_libyaml yaml-0.1>=0.1.6)
 
 find_path(libyaml_INCLUDE_DIR yaml.h
           HINTS ${PC_libyaml_INCLUDEDIR} ${PC_libyaml_INCLUDE_DIRS})

--- a/cmake/Modules/Findlibzip.cmake
+++ b/cmake/Modules/Findlibzip.cmake
@@ -1,5 +1,5 @@
 find_package(PkgConfig)
-pkg_check_modules(PC_libzip libzip>=1.1.3)
+pkg_check_modules(PC_libzip REQUIRED libzip>=1.1.3)
 
 find_path(libzip_INCLUDE_DIR zip.h
           HINTS ${PC_libzip_INCLUDEDIR} ${PC_libzip_INCLUDE_DIRS})

--- a/cmake/Modules/Findzlib.cmake
+++ b/cmake/Modules/Findzlib.cmake
@@ -1,5 +1,5 @@
 find_package(PkgConfig)
-pkg_check_modules(PC_zlib zlib>=1.2.8)
+pkg_check_modules(PC_zlib REQUIRED zlib>=1.2.8)
 
 find_path(zlib_INCLUDE_DIR zlib.h
           HINTS ${PC_zlib_INCLUDEDIR} ${PC_zlib_INCLUDE_DIRS})


### PR DESCRIPTION
the problem is modern *nix system uses GNU elfutils instead legacy libelf.
these two library lost backward compatibilty (they uses different enum value),
and out buildscripts & vita-toolchian only has compatibility with legacy version.

if system environment was mismatched, it occurs assertion errors (with local buildscripts result)
```
vita-elf-create: dest = elf_begin(fileno(*file), ELF_C_WRITE, NULL) failed: Request error: invalid ELF_C_* argument
vita-elf-create: Assertion failed: (dest = elf_utils_copy_to_file(args.output, ve->elf, &outfile))
```
or segfault (with manual built version `vita-make-fself`)

this patch will find library properly using hacky environ overwritten in the cmake scripts