### PR TITLE
Better SceLibcParam support and add support for user defined process params.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,1 @@
-build
+build*

--- a/src/sce-elf-defs.h
+++ b/src/sce-elf-defs.h
@@ -174,7 +174,7 @@ typedef struct SCE_TYPE(sce_libc_param) {
 	uint32_t unk_0x30;							  /* Unknown */
 	SCE_PTR(const void *) malloc_for_tls_replace; /* malloc_for_tls replacement functions */
 
-	uint32_t _default_heap_size;                  /* Default SceLibc heap size - 0x800000 (8MiB) */
+	uint32_t _default_heap_size;                  /* Default SceLibc heap size - 0x40000 (256KiB) */
 } SCE_TYPE(sce_libc_param);
 
 #undef SCE_TYPE

--- a/src/sce-elf-defs.h
+++ b/src/sce-elf-defs.h
@@ -40,30 +40,8 @@ typedef struct SCE_TYPE(sce_module_info) {
 	SCE_PTR(const void *) extab_top;	/* Offset to start of ARM EXTAB (optional) */
 	SCE_PTR(const void *) extab_end;	/* Offset to end of ARM EXTAB (optional */
 
-	// i decided to include process param into module_info (xyz)
-	uint32_t process_param_size;                             /* 0x34 */
-	uint32_t process_param_magic;                            /* PSP2 */
-	uint32_t process_param_ver;                              /* unknown, but it could be 6 */
-	uint32_t process_param_fw_ver;                           /* sdk vsersion */
-	SCE_PTR(const char *) process_param_main_thread_name;    /* thread name pointer*/
-	SCE_PTR(int32_t *) process_param_main_thread_priority;   /* thread initPriority */
-	SCE_PTR(uint32_t *) process_param_main_thread_stacksize; /* thread stacksize*/
-	uint32_t process_param_main_thread_attribute;            /* unknown */
-	SCE_PTR(const char *) process_param_process_name;        /* process name pointer */
-	/*
-	 * 0x01000000 - SceLibPvf
-	 * 0x00800000 - SceLibft2
-	 * 0x00400000 - SceAppUtil
-	 * 0x00200000 - unknown
-	 * 0x00100000 - SceCommonDialog
-	 * 0x00080000 - SceShellSvc
-	 * 0x00040000 - unknown
-	 * 0x00020000 - SceLibDbg and SceLibPvf
-	 */
-	SCE_PTR(uint32_t *) process_param_process_preload_disabled; /* module load inhibit */
-	uint32_t process_param_main_thread_cpu_affinity_mask;       /* unknown */
-	SCE_PTR(const void *) process_param_sce_libc_param;         /* SceLibc param pointer */
-	uint32_t process_param_unk;                                 /* unknown */
+	// Included module_sdk_version export in module_info
+	uint32_t module_sdk_version;        /* SDK version */
 } SCE_TYPE(sce_module_info);
 
 typedef struct SCE_TYPE(sce_module_exports) {
@@ -115,6 +93,89 @@ typedef struct SCE_TYPE(sce_module_imports_short) {
 	SCE_PTR(uint32_t *) var_nid_table;			/* Pointer to array of variable NIDs to import */
 	SCE_PTR(const void **) var_entry_table;		/* Pointer to array of data pointers to write to */
 } SCE_TYPE(sce_module_imports_short);
+
+typedef struct SCE_TYPE(sce_process_param) {
+	uint32_t size;                          /* 0x34 */
+	uint32_t magic;                         /* PSP2 */
+	uint32_t version;                       /* Unknown, but it could be 6 */
+	uint32_t fw_version;                    /* SDK vsersion */
+	SCE_PTR(const char *) main_thread_name; /* Thread name pointer*/
+	int32_t main_thread_priority;           /* Thread initPriority */
+	uint32_t main_thread_stacksize;         /* Thread stacksize*/
+	uint32_t main_thread_attribute;         /* Unknown */
+	SCE_PTR(const char *) process_name;     /* Process name pointer */
+	/*
+	 * 0x01000000 - SceLibPvf
+	 * 0x00800000 - SceLibft2
+	 * 0x00400000 - SceAppUtil
+	 * 0x00200000 - unknown
+	 * 0x00100000 - SceCommonDialog
+	 * 0x00080000 - SceShellSvc
+	 * 0x00040000 - unknown
+	 * 0x00020000 - SceLibDbg and SceLibPvf
+	 */
+	uint32_t process_preload_disabled;      /* Module load inhibit */
+	uint32_t main_thread_cpu_affinity_mask; /* Unknown */
+	SCE_PTR(const void *) sce_libc_param;   /* SceLibc param pointer */
+	uint32_t unk;                           /* Unknown */
+} SCE_TYPE(sce_process_param);
+
+typedef struct SCE_TYPE(sce_libc_param) {
+	struct {
+		uint32_t       size;                /* 0x34 */
+		uint32_t       unk_0x4;             /* Unknown, set to 1 */
+		SCE_PTR(void *) malloc_init;        /* Initialize malloc heap */
+		SCE_PTR(void *) malloc_term;        /* Terminate malloc heap */
+		SCE_PTR(void *) malloc;             /* malloc replacement */
+		SCE_PTR(void *) free;               /* free replacement */
+		SCE_PTR(void *) calloc;             /* calloc replacement */
+		SCE_PTR(void *) realloc;            /* realloc replacement */
+		SCE_PTR(void *) memalign;           /* memalign replacement */
+		SCE_PTR(void *) reallocalign;       /* reallocalign replacement */
+		SCE_PTR(void *) malloc_stats;       /* malloc_stats replacement */
+		SCE_PTR(void *) malloc_stats_fast;  /* malloc_stats_fast replacement */
+		SCE_PTR(void *) malloc_usable_size; /* malloc_usable_size replacement */
+	} _malloc_replace;
+
+	struct {
+		uint32_t size;                               /* 0x28 */
+		uint32_t unk_0x4;                            /* Unknown, set to 1 */
+		SCE_PTR(void *) operator_new;                /* new operator replacement */
+		SCE_PTR(void *) operator_new_nothrow;        /* new (nothrow) operator replacement */
+		SCE_PTR(void *) operator_new_arr;            /* new[] operator replacement */
+		SCE_PTR(void *) operator_new_arr_nothrow;    /* new[] (nothrow) operator replacement */
+		SCE_PTR(void *) operator_delete;             /* delete operator replacement */
+		SCE_PTR(void *) operator_delete_nothrow;     /* delete (nothrow) operator replacement */
+		SCE_PTR(void *) operator_delete_arr;         /* delete[] operator replacement */
+		SCE_PTR(void *) operator_delete_arr_nothrow; /* delete[] (nothrow) operator replacement */
+	} _new_replace;
+
+	struct {
+		uint32_t size;                       /* 0x18 */
+		uint32_t unk_0x4;                    /* Unknown, set to 1 */
+		SCE_PTR(void *) malloc_init_for_tls; /* Initialise tls malloc heap */
+		SCE_PTR(void *) malloc_term_for_tls; /* Terminate tls malloc heap */
+		SCE_PTR(void *) malloc_for_tls;      /* malloc_for_tls replacement */
+		SCE_PTR(void *) free_for_tls;        /* free_for_tls replacement */
+	} _malloc_for_tls_replace;
+
+	uint32_t size;							      /* 0x38 */
+	uint32_t unk_0x4;
+	SCE_PTR(uint32_t *) heap_size;                /* Heap size variable */
+	SCE_PTR(uint32_t *) default_heap_size;        /* Default heap size variable */
+	SCE_PTR(uint32_t *) heap_extended_alloc;      /* Unknown */
+	SCE_PTR(uint32_t *) heap_delayed_alloc;       /* Unknown */
+	uint32_t fw_version;                          /* SDK version */
+	uint32_t unk_0x1C;                            /* Unknown, set to 9 */  
+	SCE_PTR(const void *) malloc_replace;         /* malloc replacement functions */
+	SCE_PTR(const void *) new_replace;            /* new replacement functions */
+	uint32_t unk_0x28;                            /* Unknown */
+	uint32_t unk_0x2C;                            /* Unknown */
+	uint32_t unk_0x30;							  /* Unknown */
+	SCE_PTR(const void *) malloc_for_tls_replace; /* malloc_for_tls replacement functions */
+
+	uint32_t _default_heap_size;                  /* Default SceLibc heap size - 0x800000 (8MiB) */
+} SCE_TYPE(sce_libc_param);
 
 #undef SCE_TYPE
 #undef SCE_PTR

--- a/src/sce-elf.h
+++ b/src/sce-elf.h
@@ -4,34 +4,37 @@
 #include "vita-elf.h"
 
 /* SCE-specific definitions for e_type: */
-#define ET_SCE_EXEC		0xFE00		/* SCE Executable file */
-#define ET_SCE_RELEXEC		0xFE04		/* SCE Relocatable file */
-#define ET_SCE_STUBLIB		0xFE0C		/* SCE SDK Stubs */
-#define ET_SCE_DYNAMIC		0xFE18		/* Unused */
-#define ET_SCE_PSPRELEXEC	0xFFA0		/* Unused (PSP ELF only) */
-#define ET_SCE_PPURELEXEC	0xFFA4		/* Unused (SPU ELF only) */
-#define ET_SCE_UNK		0xFFA5		/* Unknown */
+#define ET_SCE_EXEC         0xFE00		/* SCE Executable file */
+#define ET_SCE_RELEXEC      0xFE04		/* SCE Relocatable file */
+#define ET_SCE_STUBLIB      0xFE0C		/* SCE SDK Stubs */
+#define ET_SCE_DYNAMIC      0xFE18		/* Unused */
+#define ET_SCE_PSPRELEXEC   0xFFA0		/* Unused (PSP ELF only) */
+#define ET_SCE_PPURELEXEC   0xFFA4		/* Unused (SPU ELF only) */
+#define ET_SCE_UNK          0xFFA5		/* Unknown */
 
 /* SCE-specific definitions for sh_type: */
-#define SHT_SCE_RELA		0x60000000	/* SCE Relocations */
-#define SHT_SCENID		0x61000001	/* Unused (PSP ELF only) */
-#define SHT_SCE_PSPRELA		0x700000A0	/* Unused (PSP ELF only) */
-#define SHT_SCE_ARMRELA		0x700000A4	/* Unused (PSP ELF only) */
+#define SHT_SCE_RELA       0x60000000	/* SCE Relocations */
+#define SHT_SCENID         0x61000001	/* Unused (PSP ELF only) */
+#define SHT_SCE_PSPRELA    0x700000A0	/* Unused (PSP ELF only) */
+#define SHT_SCE_ARMRELA    0x700000A4	/* Unused (PSP ELF only) */
 
 /* SCE-specific definitions for p_type: */
-#define PT_SCE_RELA		0x60000000	/* SCE Relocations */
-#define PT_SCE_COMMENT		0x6FFFFF00	/* Unused */
-#define PT_SCE_VERSION		0x6FFFFF01	/* Unused */
-#define PT_SCE_UNK		0x70000001	/* Unknown */
-#define PT_SCE_PSPRELA		0x700000A0	/* Unused (PSP ELF only) */
-#define PT_SCE_PPURELA		0x700000A4	/* Unused (SPU ELF only) */
+#define PT_SCE_RELA       0x60000000	/* SCE Relocations */
+#define PT_SCE_COMMENT    0x6FFFFF00	/* Unused */
+#define PT_SCE_VERSION    0x6FFFFF01	/* Unused */
+#define PT_SCE_UNK        0x70000001	/* Unknown */
+#define PT_SCE_PSPRELA    0x700000A0	/* Unused (PSP ELF only) */
+#define PT_SCE_PPURELA    0x700000A4	/* Unused (SPU ELF only) */
 
-#define NID_MODULE_STOP		0x79F8E492
-#define NID_MODULE_EXIT		0x913482A9
-#define NID_MODULE_START	0x935CD196
-#define NID_MODULE_BOOTSTART	0x5C424D40
-#define NID_MODULE_INFO		0x6C2224BA
-#define NID_PROCESS_PARAM	0x70FBA1E7
+#define NID_MODULE_STOP         0x79F8E492
+#define NID_MODULE_EXIT         0x913482A9
+#define NID_MODULE_START        0x935CD196
+#define NID_MODULE_BOOTSTART    0x5C424D40
+#define NID_MODULE_INFO         0x6C2224BA
+#define NID_PROCESS_PARAM       0x70FBA1E7
+#define NID_MODULE_SDK_VERSION  0x936C8A78
+
+#define PSP2_SDK_VERSION 0x03570011
 
 typedef union {
 	Elf32_Word r_short : 4;
@@ -71,18 +74,27 @@ typedef union {
 
 /* This struct must only contain Elf32_Words, because we use it as an array in sce-elf.c */
 typedef struct {
-	Elf32_Word sceModuleInfo_rodata;	/* The sce_module_info structure */
-	Elf32_Word sceLib_ent;			/* All sce_module_exports structures */
-	Elf32_Word sceExport_rodata;		/* The tables referenced by sce_module_exports */
-	Elf32_Word sceLib_stubs;		/* All sce_module_imports structures */
-	Elf32_Word sceImport_rodata;		/* Misc data referenced by sce_module_imports */
-	Elf32_Word sceFNID_rodata;		/* The imported function NID arrays */
-	Elf32_Word sceFStub_rodata;		/* The imported function pointer arrays */
-	Elf32_Word sceVNID_rodata;		/* The imported function NID arrays */
-	Elf32_Word sceVStub_rodata;		/* The imported function NID arrays */
+	Elf32_Word sceModuleInfo_rodata;    /* The sce_module_info, sce_libc_param and sce_process_param structures */
+	Elf32_Word sceLib_ent;              /* All sce_module_exports structures */
+	Elf32_Word sceExport_rodata;        /* The tables referenced by sce_module_exports */
+	Elf32_Word sceLib_stubs;            /* All sce_module_imports structures */
+	Elf32_Word sceImport_rodata;        /* Misc data referenced by sce_module_imports */
+	Elf32_Word sceFNID_rodata;          /* The imported function NID arrays */
+	Elf32_Word sceFStub_rodata;         /* The imported function pointer arrays */
+	Elf32_Word sceVNID_rodata;          /* The imported variable NID arrays */
+	Elf32_Word sceVStub_rodata;         /* The imported variable pointer arrays */
 } sce_section_sizes_t;
 
-sce_module_info_t *sce_elf_module_info_create(vita_elf_t *ve, vita_export_t *exports);
+typedef struct {
+	sce_process_param_t* process_param;
+	sce_libc_param_t* libc_param;
+} sce_module_params_t;
+
+sce_module_params_t *sce_elf_module_params_create(vita_elf_t *ve);
+
+void sce_elf_module_params_free(sce_module_params_t *params);
+
+sce_module_info_t *sce_elf_module_info_create(vita_elf_t *ve, vita_export_t *exports, sce_process_param_t *process_param);
 
 int sce_elf_module_info_get_size(sce_module_info_t *module_info, sce_section_sizes_t *sizes);
 
@@ -90,7 +102,7 @@ void sce_elf_module_info_free(sce_module_info_t *module_info);
 
 void *sce_elf_module_info_encode(
 		const sce_module_info_t *module_info, const vita_elf_t *ve, const sce_section_sizes_t *sizes,
-		vita_elf_rela_table_t *rtable);
+		vita_elf_rela_table_t *rtable, sce_module_params_t *params);
 
 int sce_elf_write_module_info(
 		Elf *dest, const vita_elf_t *ve, const sce_section_sizes_t *sizes, void *module_info);

--- a/src/sce-elf.h
+++ b/src/sce-elf.h
@@ -90,13 +90,13 @@ typedef struct {
 	sce_libc_param_t* libc_param;
 } sce_module_params_t;
 
-sce_module_params_t *sce_elf_module_params_create(vita_elf_t *ve);
+sce_module_params_t *sce_elf_module_params_create(vita_elf_t *ve, int have_libc);
 
 void sce_elf_module_params_free(sce_module_params_t *params);
 
 sce_module_info_t *sce_elf_module_info_create(vita_elf_t *ve, vita_export_t *exports, sce_process_param_t *process_param);
 
-int sce_elf_module_info_get_size(sce_module_info_t *module_info, sce_section_sizes_t *sizes);
+int sce_elf_module_info_get_size(sce_module_info_t *module_info, sce_section_sizes_t *sizes, int have_libc);
 
 void sce_elf_module_info_free(sce_module_info_t *module_info);
 

--- a/src/vita-elf-create.c
+++ b/src/vita-elf-create.c
@@ -136,6 +136,7 @@ int main(int argc, char *argv[])
 {
 	vita_elf_t *ve;
 	sce_module_info_t *module_info;
+	sce_module_params_t *params;
 	sce_section_sizes_t section_sizes;
 	void *encoded_modinfo;
 	vita_elf_rela_table_t rtable = {};
@@ -189,7 +190,11 @@ int main(int argc, char *argv[])
 	TRACEF(VERBOSE, "Segments:\n");
 	list_segments(ve);
 
-	module_info = sce_elf_module_info_create(ve, exports);
+	params = sce_elf_module_params_create(ve);	
+	if (!params)
+		return EXIT_FAILURE;
+
+	module_info = sce_elf_module_info_create(ve, exports, params->process_param);
 
 	if (!module_info)
 		return EXIT_FAILURE;
@@ -209,7 +214,7 @@ int main(int argc, char *argv[])
 	PRINTSEC(sceVStub_rodata);
 
 	encoded_modinfo = sce_elf_module_info_encode(
-			module_info, ve, &section_sizes, &rtable);
+			module_info, ve, &section_sizes, &rtable, params);
 
 	TRACEF(VERBOSE, "Relocations from encoded modinfo:\n");
 	print_rtable(&rtable);
@@ -234,6 +239,7 @@ int main(int argc, char *argv[])
 	free(segment_sizes);
 
 	sce_elf_module_info_free(module_info);
+	sce_elf_module_params_free(module_info);
 	vita_elf_free(ve);
 
 	return status;


### PR DESCRIPTION
Moved SceProcessParam fields to a separate struct. Added SceLibcParam struct.

Added support for user definition of process param and libc param fields.

Switched to individual user definition of SceLibcParam fields, rather than user definition of the entire struct.

Added module_sdk_version export, variable exists in the sce_module_info struct.

Libc heap allocation function names were found here:
https://github.com/Olde-Skuul/burgerlib/blob/master/source/vita/brvitamemory.h