### PR TITLE
Fix error in import parsing.

### DIFF
--- a/src/sce-elf.c
+++ b/src/sce-elf.c
@@ -343,7 +343,7 @@ sce_module_info_t *sce_elf_module_info_create(vita_elf_t *ve, vita_export_t *exp
 
 	for (i = 0; i < ve->num_fstubs; i++) {
 		curstub = ve->fstubs + i;
-		curlib = varray_sorted_search_or_insert(&liblist.va, &curstub[i].library_nid, NULL);
+		curlib = varray_sorted_search_or_insert(&liblist.va, &curstub->library_nid, NULL);
 		ASSERT(curlib);
 		curlib->nid = curstub->library_nid;
 		if (curstub->library)
@@ -354,7 +354,7 @@ sce_module_info_t *sce_elf_module_info_create(vita_elf_t *ve, vita_export_t *exp
 
 	for (i = 0; i < ve->num_vstubs; i++) {
 		curstub = ve->vstubs + i;
-		curlib = varray_sorted_search_or_insert(&liblist.va, &curstub[i].library_nid, NULL);
+		curlib = varray_sorted_search_or_insert(&liblist.va, &curstub->library_nid, NULL);
 		ASSERT(curlib);
 		curlib->nid = curstub[i].library_nid;
 		if (curstub[i].library)


### PR DESCRIPTION
Error from commit 64dc1cc causing every imported function to have a separate sce_module_imports struct.

Thanks to @Princess-of-Sleeping for noticing the issue, and @frangarcj for identifying the cause.