### PR TITLE
Add support kernel weak import

### DIFF
--- a/src/vita-libs-gen.c
+++ b/src/vita-libs-gen.c
@@ -399,8 +399,6 @@ int generate_makefile(vita_imports_t **imports, int imports_count)
 		vita_imports_t *imp = imports[h];
 
 		for (i = 0; i < imp->n_modules; i++) {
-			fprintf(fp, " lib%s%s_stub_weak.a", imp->modules[i]->name, imp->postfix);
-
 			for (j = 0; j < imp->modules[i]->n_libs; j++) {
 				vita_imports_lib_t *library = imp->modules[i]->libs[j];
 
@@ -419,12 +417,12 @@ int generate_makefile(vita_imports_t **imports, int imports_count)
 			is_special = (strcmp(KERNEL_LIBS_STUB, module->name) == 0);
 
 			for (int weak = 0; weak < 2; weak++) {
-				if (!is_special) {
-					fprintf(fp, "%s%s%s =", module->name, imp->postfix, weak ? "_weak_OBJS" : "_OBJS");
-				}
-
 				for (j = 0; j < module->n_libs; j++) {
 					vita_imports_lib_t *library = module->libs[j];
+
+					if (!is_special) {
+						fprintf(fp, "%s%s%s =", library->name, imp->postfix, weak ? "_weak_OBJS" : "_OBJS");
+					}
 
 					if (!library->n_functions && !library->n_variables)
 						continue;
@@ -440,10 +438,10 @@ int generate_makefile(vita_imports_t **imports, int imports_count)
 						snprintf(buf, sizeof(buf), " %s_%s_%s%s.%s", module->name, library->name, variable->name, imp->postfix, weak ? "wo" : "o");
 						write_symbol(buf, is_special);
 					}
-				}
 
-				if (!is_special) {
-					fprintf(fp, "\n");
+					if (!is_special) {
+						fprintf(fp, "\n");
+					}
 				}
 			}
 

--- a/src/vita-libs-gen.c
+++ b/src/vita-libs-gen.c
@@ -381,8 +381,6 @@ int generate_makefile(vita_imports_t **imports, int imports_count)
 		vita_imports_t *imp = imports[h];
 
 		for (i = 0; i < imp->n_modules; i++) {
-			fprintf(fp, " lib%s%s_stub.a", imp->modules[i]->name, imp->postfix);
-
 			for (j = 0; j < imp->modules[i]->n_libs; j++) {
 				vita_imports_lib_t *library = imp->modules[i]->libs[j];
 

--- a/src/vita-libs-gen.c
+++ b/src/vita-libs-gen.c
@@ -444,33 +444,6 @@ int generate_makefile(vita_imports_t **imports, int imports_count)
 					}
 				}
 			}
-
-			for (j = 0; j < module->n_libs; j++) {
-				vita_imports_lib_t *library = module->libs[j];
-
-				if (!library->is_kernel)
-					continue;
-				if (!library->n_functions && !library->n_variables)
-					continue;
-
-				char buf[4096];
-
-				fprintf(fp, "%s%s_OBJS =", library->name, imp->postfix);
-
-				for (k = 0; k < library->n_functions; k++) {
-					vita_imports_stub_t *function = library->functions[k];
-					snprintf(buf, sizeof(buf), " %s_%s_%s%s.o", module->name, library->name, function->name, imp->postfix);
-					write_symbol(buf, 1);
-				}
-
-				for (k = 0; k < library->n_variables; k++) {
-					vita_imports_stub_t *variable = library->variables[k];
-					snprintf(buf, sizeof(buf), " %s_%s_%s%s.o", module->name, library->name, variable->name, imp->postfix);
-					write_symbol(buf, 1);
-				}
-
-				fprintf(fp, "\n");
-			}
 		}
 	}
 

--- a/src/vita-libs-gen.c
+++ b/src/vita-libs-gen.c
@@ -400,6 +400,12 @@ int generate_makefile(vita_imports_t **imports, int imports_count)
 
 		for (i = 0; i < imp->n_modules; i++) {
 			fprintf(fp, " lib%s%s_stub_weak.a", imp->modules[i]->name, imp->postfix);
+
+			for (j = 0; j < imp->modules[i]->n_libs; j++) {
+				vita_imports_lib_t *library = imp->modules[i]->libs[j];
+
+				fprintf(fp, " lib%s%s_stub_weak.a", library->name, imp->postfix);
+			}
 		}
 	}
 

--- a/src/vita-libs-gen.c
+++ b/src/vita-libs-gen.c
@@ -386,9 +386,6 @@ int generate_makefile(vita_imports_t **imports, int imports_count)
 			for (j = 0; j < imp->modules[i]->n_libs; j++) {
 				vita_imports_lib_t *library = imp->modules[i]->libs[j];
 
-				if (!library->is_kernel)
-					continue;
-
 				fprintf(fp, " lib%s%s_stub.a", library->name, imp->postfix);
 			}
 		}

--- a/src/vita-libs-gen.c
+++ b/src/vita-libs-gen.c
@@ -474,9 +474,6 @@ int generate_makefile(vita_imports_t **imports, int imports_count)
 		}
 	}
 
-	// write kernel lib stub
-	fprintf(fp, "%s_OBJS =%s\n", KERNEL_LIBS_STUB, g_kernel_objs);
-
 	fputs(
 		"ALL_OBJS=\n\n"
 		"all: $(TARGETS) $(TARGETS_WEAK)\n\n"

--- a/src/vita-libs-gen.c
+++ b/src/vita-libs-gen.c
@@ -420,8 +420,6 @@ int generate_makefile(vita_imports_t **imports, int imports_count)
 				for (j = 0; j < module->n_libs; j++) {
 					vita_imports_lib_t *library = module->libs[j];
 
-					if(library->is_kernel)
-						continue;
 					if (!library->n_functions && !library->n_variables)
 						continue;
 


### PR DESCRIPTION
https://github.com/vitasdk/vita-toolchain/issues/171

The weak import added by this change allows you to load a module even if you are importing a library that has not yet been loaded.