### PR TITLE
Allow pkg-config to auto-detect and override prefix

### DIFF
--- a/pkgconfig/arm-vita-eabi-pkg-config
+++ b/pkgconfig/arm-vita-eabi-pkg-config
@@ -8,7 +8,7 @@ export PKG_CONFIG_DIR=
 export PKG_CONFIG_PATH=
 export PKG_CONFIG_SYSROOT_DIR=
 
-export PKG_CONFIG_LIBDIR=${VITASDK}/arm-vita-eabi/lib/pkgconfig
+export PKG_CONFIG_LIBDIR=${VITASDK}/arm-vita-eabi/lib/pkgconfig:${VITASDK}/arm-vita-eabi/share/pkgconfig
 
 [[ "$1" == '--version' ]] && exec pkg-config --version
 exec pkg-config --define-prefix --static "$@"

--- a/pkgconfig/arm-vita-eabi-pkg-config
+++ b/pkgconfig/arm-vita-eabi-pkg-config
@@ -11,4 +11,4 @@ export PKG_CONFIG_SYSROOT_DIR=
 export PKG_CONFIG_LIBDIR=${VITASDK}/arm-vita-eabi/lib/pkgconfig
 
 [[ "$1" == '--version' ]] && exec pkg-config --version
-exec pkg-config --static "$@"
+exec pkg-config --define-prefix --static "$@"


### PR DESCRIPTION
That should fix https://github.com/vitasdk/vdpm/issues/69
Although, having proper prefix would still be nice.