### PR TITLE
chore: bump minimum cmake

### DIFF
--- a/cmake_toolchain/vita.toolchain.cmake
+++ b/cmake_toolchain/vita.toolchain.cmake
@@ -30,7 +30,7 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-cmake_minimum_required( VERSION 2.6.3 )
+cmake_minimum_required( VERSION 2.8.12 )
 
 if( DEFINED CMAKE_CROSSCOMPILING )
   # subsequent toolchain loading is not really needed


### PR DESCRIPTION
Hi, I'm running the latest cmake:

```sh
$ cmake --version
cmake version 3.20.1
```

And I keep getting this annoying warning:

```
cmake ../.. 
CMake Deprecation Warning at /usr/local/vitasdk/share/vita.toolchain.cmake:33 (cmake_minimum_required):
  Compatibility with CMake < 2.8.12 will be removed from a future version of
  CMake.

  Update the VERSION argument <min> value or use a ...<max> suffix to tell
  CMake that the project does not need compatibility with older versions.
Call Stack (most recent call first):
  Debug/vita/CMakeFiles/3.20.1/CMakeSystem.cmake:6 (include)
  CMakeLists.txt:30 (project)
```

Wondering if we could do a bump?