### PR TITLE
Implement module_sdk_version dependent on user global variable

### DIFF
--- a/src/sce-elf-defs.h
+++ b/src/sce-elf-defs.h
@@ -15,7 +15,7 @@
 struct SCE_TYPE(sce_module_exports);
 struct SCE_TYPE(sce_module_imports);
 
-typedef struct SCE_TYPE(sce_module_info) {
+typedef struct SCE_TYPE(sce_module_info) { // size is 0x5C-bytes
 	uint16_t attributes;
 	uint16_t version;			/* Set to 0x0101 */
 	char name[27];				/* Name of the library */
@@ -39,9 +39,6 @@ typedef struct SCE_TYPE(sce_module_info) {
 	SCE_PTR(const void *) exidx_end;	/* Offset to end of ARM EXIDX (optional) */
 	SCE_PTR(const void *) extab_top;	/* Offset to start of ARM EXTAB (optional) */
 	SCE_PTR(const void *) extab_end;	/* Offset to end of ARM EXTAB (optional */
-
-	// Included module_sdk_version export in module_info
-	uint32_t module_sdk_version;        /* SDK version */
 } SCE_TYPE(sce_module_info);
 
 typedef struct SCE_TYPE(sce_module_exports) {

--- a/src/vita-elf-create.c
+++ b/src/vita-elf-create.c
@@ -536,6 +536,22 @@ int main(int argc, char *argv[])
 	TRACEF(VERBOSE, "Segments:\n");
 	list_segments(ve);
 
+	// Enter module module_sdk_version
+	{
+		Elf32_Addr module_sdk_version_address = 0xFFFFFFFF;
+		if (get_variable_by_symbol("module_sdk_version", ve, &module_sdk_version_address) == 1) {
+			const uint32_t *module_sdk_version_ptr = vita_elf_vaddr_to_host(ve, module_sdk_version_address);
+			ASSERT(module_sdk_version_ptr != NULL);
+
+			ve->module_sdk_version = *module_sdk_version_ptr;
+			ve->module_sdk_version_ptr = module_sdk_version_address;
+		}
+		else { // failback
+			ve->module_sdk_version = PSP2_SDK_VERSION;
+			ve->module_sdk_version_ptr = 0xFFFFFFFF;
+		}
+	}
+
 	have_libc = get_variable_by_symbol("sceLibcHeapSize", ve, NULL)
 				|| get_variable_by_symbol("sceLibcHeapExtendedAlloc", ve, NULL)
 				|| get_variable_by_symbol("sceLibcHeapDelayedAlloc", ve, NULL)

--- a/src/vita-elf.c
+++ b/src/vita-elf.c
@@ -653,10 +653,15 @@ vita_elf_t *vita_elf_load(const char *filename, int check_stub_count)
 		curseg->memsz = phdr.p_memsz;
 
 		if (curseg->memsz) {
-			curseg->vaddr_top = mmap(NULL, curseg->memsz, PROT_NONE, MAP_PRIVATE | MAP_ANONYMOUS | MAP_NORESERVE, -1, 0);
+			curseg->vaddr_top = mmap(NULL, curseg->memsz, /* PROT_NONE */ PROT_WRITE | PROT_READ, MAP_PRIVATE | MAP_ANONYMOUS | MAP_NORESERVE, -1, 0);
 			if (curseg->vaddr_top == NULL)
 				FAIL("Could not allocate address space for segment %d", (int)segndx);
 			curseg->vaddr_bottom = curseg->vaddr_top + curseg->memsz;
+
+			fseek(ve->file, phdr.p_offset, SEEK_SET);
+			if(fread((void *)(curseg->vaddr_top), curseg->memsz, 1, ve->file) != 1){
+				FAIL("Could not read for segment %d", (int)segndx);
+			}
 		}
 		
 		loaded_segments++;

--- a/src/vita-elf.h
+++ b/src/vita-elf.h
@@ -71,6 +71,9 @@ typedef struct vita_elf_t {
 	int mode;
 	Elf *elf;
 
+	uint32_t module_sdk_version;
+	Elf32_Addr module_sdk_version_ptr;
+
 	varray fstubs_va;
 	varray vstubs_va;
 


### PR DESCRIPTION
Since current vita-toolchian always exports module_sdk_version and its value is fixed at 0x3570011, running programs on older firmware versions is a very cumbersome procedure using some external tools. and had to change the module_sdk_version.

However this PR make module_sdk_version as a module export from a global variable in the user controllable project source code.

# Example code

toolchain until now -> module_sdk_version is 0x3570011 always because toolchain fixed it
```
const SceUInt32 module_sdk_version = 0x3600011;
int module_start(){
    ... code
}
```

This PR -> module_sdk_version is 0x3600011 from source code
```
const SceUInt32 module_sdk_version = 0x3600011;
int module_start(){
    ... code
}
```

However, this PR changes not only module_sdk_version, but also fw_version in process_param/libc_param depending on module_sdk_version.

Also, if the module_sdk_version variable does not exist, module_sdk_version is not exported and fw_version of process_param/libc_param is still set to 0x3570011.


[Another change](https://github.com/vitasdk/vita-toolchain/commit/efef6468b6ae74c6ea2b0bedf8bab5053a0e619c#diff-d92f801bff5de77f87c2637055b0850dd71349fed2a942138d453656b3a88236R655-R665) is to allow mmap to be accessed as a temporary segment. This is for reading module_sdk_version.

