### PR TITLE
vita-mksfoex: Fix 32-bit write to 8-bit field

### DIFF
--- a/src/vita-mksfoex.c
+++ b/src/vita-mksfoex.c
@@ -300,10 +300,10 @@ int main(int argc, char **argv)
 	for(i = 0; g_vals[i].name; i++)
 	{
 		SW(&h->count, ++count);
-		SW(&e->nameofs, k-keys);
+		SH(&e->nameofs, k-keys);
 		SW(&e->dataofs, d-data);
-		SW(&e->alignment, 4);
-		SW(&e->type, g_vals[i].type);
+		e->alignment = 4;
+		e->type = g_vals[i].type;
 
 		strcpy(k, g_vals[i].name);
 		k += strlen(k)+1;


### PR DESCRIPTION
I found this bug while I was reading over this file. The code is pretty old and kinda janky. This fixes vita-mksfoex on big endian, if anyone ever attempts to use that.