### PR TITLE
Make sure using VITASDK variable in pc files always works

### DIFF
--- a/pkgconfig/arm-vita-eabi-pkg-config
+++ b/pkgconfig/arm-vita-eabi-pkg-config
@@ -11,4 +11,4 @@ export PKG_CONFIG_SYSROOT_DIR=
 export PKG_CONFIG_LIBDIR=${VITASDK}/arm-vita-eabi/lib/pkgconfig:${VITASDK}/arm-vita-eabi/share/pkgconfig
 
 [[ "$1" == '--version' ]] && exec pkg-config --version
-exec pkg-config --define-prefix --static "$@"
+exec pkg-config --define-variable=VITASDK=${VITASDK} --define-prefix --static "$@"


### PR DESCRIPTION
There probably isn't an issue with this right now, but it's nice to have the ability to just use VITASDK in pc files and have it work in all cases.