### PR TITLE
Add -fno-strict-aliasing flag

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -7,8 +7,8 @@ include_directories(${libelf_INCLUDE_DIRS})
 include_directories(${zlib_INCLUDE_DIRS})
 include_directories(${libzip_INCLUDE_DIRS})
 
-set(CMAKE_C_FLAGS "-fvisibility=hidden -g -std=gnu99")
-set(CMAKE_CXX_FLAGS "-fvisibility=hidden -g -std=gnu++11")
+set(CMAKE_C_FLAGS "-fno-strict-aliasing -fvisibility=hidden -g -std=gnu99")
+set(CMAKE_CXX_FLAGS "-fno-strict-aliasing -fvisibility=hidden -g -std=gnu++11")
 
 enable_language(C CXX)
 


### PR DESCRIPTION
I've found strict aliasing violations regularly occuring in the code. Example:
https://github.com/vitasdk/vita-toolchain/blob/bbb2c95d41cd4037df86529217387979745426b6/src/vita-libs-gen-2.cpp#L545-L546