### PR TITLE
vita.toolchain.cmake: cache pkg-config path

### DIFF
--- a/cmake_toolchain/vita.toolchain.cmake
+++ b/cmake_toolchain/vita.toolchain.cmake
@@ -107,7 +107,7 @@ set( BUILD_VITA True )
 # where is the target environment
 set( CMAKE_FIND_ROOT_PATH "${VITASDK}/bin" "${VITASDK}/arm-vita-eabi" "${CMAKE_INSTALL_PREFIX}" "${CMAKE_INSTALL_PREFIX}/share" )
 set( CMAKE_INSTALL_PREFIX "${VITASDK}/arm-vita-eabi" CACHE PATH "default install path" )
-set( PKG_CONFIG_EXECUTABLE "${VITASDK}/bin/arm-vita-eabi-pkg-config" )
+set( PKG_CONFIG_EXECUTABLE "${VITASDK}/bin/arm-vita-eabi-pkg-config" CACHE PATH "Path of pkg-config executable" )
 
 # only search for libraries and includes in vita toolchain
 if( NOT CMAKE_FIND_ROOT_PATH_MODE_LIBRARY )


### PR DESCRIPTION
`PKG_CONFIG_EXECUTABLE` needs to be cached, such that the [`find_program`](https://github.com/Kitware/CMake/blob/bc82d62b1bb484aabb1fdbb563c44f6e7cffb55f/Modules/FindPkgConfig.cmake#L62-L66) in [`FindPkgConfig`](https://cmake.org/cmake/help/latest/module/FindPkgConfig.html) will use the custom one.

Without this change, [SDL](https://github.com/libsdl-org/SDL/pull/8366) cannot use [`pkg_check_modules`](https://cmake.org/cmake/help/latest/module/FindPkgConfig.html#command:pkg_check_modules) to find the dependencies of the static ffmpeg libraries.