### PR TITLE
Make a select the appropriate scenario for velf

### DIFF
--- a/src/vita-elf-create/sce-elf.h
+++ b/src/vita-elf-create/sce-elf.h
@@ -107,7 +107,12 @@ typedef struct {
 	sce_libc_param_t* libc_param;
 } sce_module_params_t;
 
-sce_module_params_t *sce_elf_module_params_create(vita_elf_t *ve, int have_libc);
+/**
+ * function: sce_elf_module_params_create
+ *
+ * Create process_param and libc_param
+ */
+sce_module_params_t *sce_elf_module_params_create(vita_elf_t *ve, vita_export_t *exports, int have_libc);
 
 void sce_elf_module_params_free(sce_module_params_t *params);
 

--- a/src/vita-elf-create/vita-elf.c
+++ b/src/vita-elf-create/vita-elf.c
@@ -540,7 +540,7 @@ failure:
 	return 0;
 }
 
-vita_elf_t *vita_elf_load(const char *filename, int check_stub_count)
+vita_elf_t *vita_elf_load(const char *filename, int check_stub_count, vita_export_t *export)
 {
 	vita_elf_t *ve = NULL;
 	GElf_Ehdr ehdr;
@@ -623,7 +623,7 @@ vita_elf_t *vita_elf_load(const char *filename, int check_stub_count)
 	if (ve->symtab == NULL)
 		FAILX("No symbol table in binary, perhaps stripped out");
 
-	if (ve->rela_tables == NULL)
+	if (ve->rela_tables == NULL && export != NULL && export->is_image_module == 0)
 		FAILX("No relocation sections in binary; use -Wl,-q while compiling");
 
 	if (ve->fstubs_va.count != 0) {

--- a/src/vita-elf-create/vita-elf.h
+++ b/src/vita-elf-create/vita-elf.h
@@ -92,7 +92,7 @@ typedef struct vita_elf_t {
 	int num_segments;
 } vita_elf_t;
 
-vita_elf_t *vita_elf_load(const char *filename, int check_stub_count);
+vita_elf_t *vita_elf_load(const char *filename, int check_stub_count, vita_export_t *export);
 void vita_elf_free(vita_elf_t *ve);
 
 void vita_elf_generate_exports(vita_elf_t *ve, vita_export_t *exports);

--- a/src/vita-export-parse.c
+++ b/src/vita-export-parse.c
@@ -483,6 +483,25 @@ int process_module_info(yaml_node *parent, yaml_node *child, vita_export_t *info
 		info->attributes = (uint16_t)attrib32;
 	}
 
+	else if (strcmp(key->value, "process_image") == 0) {
+
+		if (!is_scalar(child)) {
+			fprintf(stderr, "error: line: %zd, column: %zd, expecting process_image to be scalar, got '%s'.\n", child->position.line, child->position.column, node_type_str(child));
+			return -1;
+		}
+
+		key = &child->data.scalar;
+
+		if (strcmp(key->value, "true") == 0) {
+			info->is_process_image = 1;
+		} else if (strcmp(key->value, "false") == 0) {
+			info->is_process_image = 0;
+		} else {
+			fprintf(stderr, "error: line: %zd, column: %zd, Received unexpected value in process_image, got '%s'. Vaild value is \"true\" or \"false\".\n", child->position.line, child->position.column, key->value);
+			return -1;
+		}
+	}
+
 	else if (strcmp(key->value, "imagemodule") == 0) {
 
 		if (!is_scalar(child)) {
@@ -658,6 +677,14 @@ vita_export_t *vita_export_generate_default(const char *elf)
 		return NULL;
 	}
 
+	/*
+	 * | is_process_image | is_image_module |
+	 * | 0                | 0               | prx
+	 * | 0                | 1               | bootimage.skprx
+	 * | 1                | 0               | eboot.bin
+	 * | 1                | 1               | undefined
+	 */
+	exports->is_process_image = 1;
 	exports->is_image_module = 0;
 	
 	// we don't specify any specific symbols

--- a/src/vita-export.h
+++ b/src/vita-export.h
@@ -28,6 +28,7 @@ typedef struct {
 	uint8_t ver_minor;
 	uint16_t attributes;
 	uint32_t nid;
+	int is_process_image;
 	int is_image_module;
 	const char *bootstart;
 	const char *start;


### PR DESCRIPTION
- The image module (.elf) no longer requires rel info completely.
- Automatically generate process_param according to process_image/image module.
- module_info alignment to 4-bytes. (So should not be encount to `vita-elf-create: elf_update(dest, ELF_C_WRITE) >= 0 failed: Layout error: overlapping sections`)
- Some tweak.