### PR TITLE
fix Argument list too long in vita-libs-gen-2 generated makefile

### DIFF
--- a/src/vita-libs-gen-2/vita-libs-gen-2.cpp
+++ b/src/vita-libs-gen-2/vita-libs-gen-2.cpp
@@ -409,7 +409,7 @@ int gen_makefile(const char *dstdir, StubContext *stub_ctx){
 	fprintf(fp, "clean:\n");
 	fprintf(fp, "\trm -f $(TARGETS) $(TARGETS_WEAK) $(ALL_OBJS)\n\n");
 	fprintf(fp, "$(TARGETS) $(TARGETS_WEAK):\n");
-	fprintf(fp, "\t@echo \"$?\" > $@-objs\n");
+	fprintf(fp, "\t$(file >$@-objs,$?)\n");
 	fprintf(fp, "\t$(AR) cru $@ @$@-objs\n");
 	fprintf(fp, "\t$(RANLIB) $@\n");
 	fprintf(fp, "\trm $^ $@-objs\n\n");


### PR DESCRIPTION
error "Argument list too long" if there are too many functions in the yml with echo
writing to file using https://www.gnu.org/software/make/manual/html_node/File-Function.html works better