### PR TITLE
vita-elf-create: fix GPU texture corruption on real Vita

### DIFF
--- a/src/vita-elf-create/sce-elf.c
+++ b/src/vita-elf-create/sce-elf.c
@@ -377,7 +377,7 @@ sce_module_params_t *sce_elf_module_params_create(vita_elf_t *ve, vita_export_t 
 		ASSERT(process_param != NULL);
 		process_param->size = 0x34;
 		memcpy(&(process_param->magic), "PSP2", 4);
-		process_param->version = 6;
+		process_param->version = 0;
 		process_param->fw_version = params->process_param_version;
 
 		params->process_param = process_param;
@@ -391,7 +391,7 @@ sce_module_params_t *sce_elf_module_params_create(vita_elf_t *ve, vita_export_t 
 		ASSERT(process_param != NULL);
 		process_param->size = 0x30;
 		memcpy(&(process_param->magic), "PSP2", 4);
-		process_param->version = 5;
+		process_param->version = 0;
 		process_param->fw_version = params->process_param_version;
 
 		params->process_param = process_param;


### PR DESCRIPTION
This PR fixes a regression introduced after commit [https://github.com/vitasdk/vita-toolchain/commit/69ece3eba09ce8390afaad8b1572fb0fe13c9ee8], last working toolchain was v1115.
That change causes GPU texture sampling to fail on real PS Vita hardware when using libgxm, while still appearing correct in Vita3K.

On hardware, any shader using tex2D() returns solid color (texture`s first pixel).
The same ELF runs perfectly under Vita3K emulator.
Reproduced across multiple devices and projects.
The issue is triggered by process_param->version = 6 (or 5); only 0 works.