### PR TITLE
add exidx & extab to module info

### DIFF
--- a/src/vita-elf-create/sce-elf.c
+++ b/src/vita-elf-create/sce-elf.c
@@ -504,10 +504,22 @@ sce_module_info_t *sce_elf_module_info_create(vita_elf_t *ve, vita_export_t *exp
 		set_module_import(ve, module_info->import_top + i, liblist.libs + i);
 	}
 
-	// fake param. Required for old fw.
-	if (ve->module_sdk_version < VITA_TOOLCHAIN_PROCESS_PARAM_NEW_FORMAT_VERSION) {
-		module_info->exidx_top = ve->segments[0].vaddr_top + 0;
-		module_info->exidx_end = ve->segments[0].vaddr_top + 1;
+	if (ve->exidx_sh_size > 0) {
+		uint32_t exidx_offset = ve->exidx_sh_addr - ve->segments[0].vaddr;
+		module_info->exidx_top = ve->segments[0].vaddr_top + exidx_offset;
+		module_info->exidx_end = module_info->exidx_top + ve->exidx_sh_size;
+	} else {
+		module_info->exidx_top = 0;
+		module_info->exidx_end = 0;
+	}
+
+	if (ve->extab_sh_size > 0) {
+		uint32_t extab_offset = ve->extab_sh_addr - ve->segments[0].vaddr;
+		module_info->extab_top = ve->segments[0].vaddr_top + extab_offset;
+		module_info->extab_end = module_info->extab_top + ve->extab_sh_size;
+	} else {
+		module_info->extab_top = 0;
+		module_info->extab_end = 0;
 	}
 
 	return module_info;

--- a/src/vita-elf-create/vita-elf.c
+++ b/src/vita-elf-create/vita-elf.c
@@ -599,6 +599,12 @@ vita_elf_t *vita_elf_load(const char *filename, int check_stub_count, vita_expor
 			varray_push(&ve->vstubs_va,&ndxscn);
 			if (!load_stubs(scn, &ve->num_vstubs, &ve->vstubs, name))
 				goto failure;
+		} else if (shdr.sh_type == SHT_ARM_EXIDX && strncmp(name, ".ARM.exidx", strlen(".ARM.exidx")) == 0) {
+			ve->exidx_sh_addr = shdr.sh_addr;
+			ve->exidx_sh_size = shdr.sh_size;
+		} else if (shdr.sh_type == SHT_PROGBITS && strncmp(name, ".ARM.extab", strlen(".ARM.extab")) == 0) {
+			ve->extab_sh_addr = shdr.sh_addr;
+			ve->extab_sh_size = shdr.sh_size;
 		}
 
 		if (shdr.sh_type == SHT_SYMTAB) {

--- a/src/vita-elf-create/vita-elf.h
+++ b/src/vita-elf-create/vita-elf.h
@@ -90,6 +90,11 @@ typedef struct vita_elf_t {
 
 	vita_elf_segment_info_t *segments;
 	int num_segments;
+
+	Elf32_Addr exidx_sh_addr;
+	Elf32_Word exidx_sh_size;
+	Elf32_Addr extab_sh_addr;
+	Elf32_Word extab_sh_size;
 } vita_elf_t;
 
 vita_elf_t *vita_elf_load(const char *filename, int check_stub_count, vita_export_t *export);


### PR DESCRIPTION
sets the exidx and extab offsets correctly instead of stubbing them to zero