### PR TITLE
test: Add golden-master VELF layout regression check

### DIFF
--- a/test/regen_golden.sh
+++ b/test/regen_golden.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+# Regenerates the golden VELF fixtures used by test_elf_create.py's layout
+# regression check (#47). Run this after an intentional change to VELF
+# layout/alignment, then review the resulting diff of fixtures/*.velf.
+#
+# Usage: test/regen_golden.sh <path-to-vita-elf-create>
+
+set -e
+
+if [ -z "$1" ]; then
+    echo "Usage: $0 <path-to-vita-elf-create>" >&2
+    exit 1
+fi
+
+ELF_CREATE="$1"
+FIXTURES_DIR="$(cd "$(dirname "$0")/fixtures" && pwd)"
+
+"$ELF_CREATE" "$FIXTURES_DIR/sample.elf" "$FIXTURES_DIR/sample.velf"
+"$ELF_CREATE" -n "$FIXTURES_DIR/sample_exidx.elf" "$FIXTURES_DIR/sample_exidx.velf"
+
+echo "Regenerated $FIXTURES_DIR/sample.velf and sample_exidx.velf — review with 'git diff --stat' and the section-table output from a failing test run before committing."

--- a/test/test_elf_create.py
+++ b/test/test_elf_create.py
@@ -32,6 +32,45 @@ def inspect_velf_sections(velf_path):
         }
     return sections
 
+def compare_to_golden(generated_path, golden_path, label):
+    with open(generated_path, 'rb') as f:
+        gen_data = f.read()
+    with open(golden_path, 'rb') as f:
+        golden_data = f.read()
+
+    if gen_data == golden_data:
+        return
+
+    gen_secs = inspect_velf_sections(generated_path)
+    golden_secs = inspect_velf_sections(golden_path)
+    gen_names = list(gen_secs.keys())
+    golden_names = list(golden_secs.keys())
+
+    lines = [f"{label}: generated VELF does not match golden fixture {golden_path}"]
+    if gen_names != golden_names:
+        lines.append(f"  section order differs:\n    golden:    {golden_names}\n    generated: {gen_names}")
+    else:
+        for name in golden_names:
+            g, n = golden_secs[name], gen_secs[name]
+            if g['offset'] != n['offset'] or g['size'] != n['size']:
+                lines.append(
+                    f"  {name}: golden offset=0x{g['offset']:x} size=0x{g['size']:x}"
+                    f"  generated offset=0x{n['offset']:x} size=0x{n['size']:x}"
+                )
+    if len(gen_data) != len(golden_data):
+        lines.append(f"  file size differs: golden={len(golden_data)} generated={len(gen_data)}")
+
+    diff_offset = next((i for i in range(min(len(gen_data), len(golden_data))) if gen_data[i] != golden_data[i]), None)
+    if diff_offset is not None:
+        containing = next(
+            (name for name, s in golden_secs.items() if s['offset'] <= diff_offset < s['offset'] + s['size']),
+            "(no known section / in ELF/program headers)"
+        )
+        lines.append(f"  first differing byte at file offset 0x{diff_offset:x}, inside section {containing}")
+
+    lines.append("  If this is an intentional layout change, regenerate with: test/regen_golden.sh <path-to-vita-elf-create>")
+    raise AssertionError("\n".join(lines))
+
 def main():
     if len(sys.argv) < 2:
         print("Usage: test_elf_create.py <path-to-vita-elf-create>")
@@ -74,7 +113,16 @@ def main():
         assert extab_end == 0x14, f"Expected extab_end 0x14, got {hex(extab_end)}"
         assert exidx_top == 0x14, f"Expected exidx_top 0x14, got {hex(exidx_top)}"
         assert exidx_end == 0x24, f"Expected exidx_end 0x24, got {hex(exidx_end)}"
-        
+
+        # Test 3: Golden-master layout regression check (#47).
+        # Byte-exact comparison against checked-in reference VELFs, so a layout/alignment
+        # regression is caught even when the section presence/value checks above still pass.
+        golden1 = os.path.join(fixtures_dir, "sample.velf")
+        compare_to_golden(velf1, golden1, "sample.elf")
+
+        golden2 = os.path.join(fixtures_dir, "sample_exidx.velf")
+        compare_to_golden(velf2, golden2, "sample_exidx.elf")
+
     print("test_elf_create: ALL TESTS PASSED")
 
 if __name__ == "__main__":


### PR DESCRIPTION
Adds a byte-exact comparison of `vita-elf-create`'s output against the checked-in `fixtures/sample.velf`/`sample_exidx.velf`, so a layout/alignment regression gets caught even when the section-presence/value checks in Test 1/2 still pass — this is the gold-master approach yifanlu described in #47 back in 2016 (input ELF + reference output VELF, check that section offsets and order match), just wired up now that the fixtures already exist.

On mismatch it reports section order/offset/size differences and the first differing file offset, instead of a bare byte diff. `test/regen_golden.sh <path-to-vita-elf-create>` regenerates the fixtures after an intentional layout change, for review via `git diff`.

Doesn't cover relocation-heavy layouts (#150/#225/#274) — makes more sense to add fixtures for those alongside whoever fixes them.

Closes #47