### PR TITLE
cmake: add SECRETSAFE option to vita_create_self

### DIFF
--- a/cmake_toolchain/vita.cmake
+++ b/cmake_toolchain/vita.cmake
@@ -25,6 +25,7 @@ include(CMakeParseArguments)
 ##                    [CONFIG file | GEN_EXPORTS file]
 ##                    [UNCOMPRESSED]
 ##                    [UNSAFE]
+##                    [SECRETSAFE]
 ##                    [STRIPPED]
 ##                    [NOASLR]
 ##                    [REL_OPTIMIZE]
@@ -41,6 +42,9 @@ include(CMakeParseArguments)
 ##   Do NOT compress the result SELF (compression is default)
 ## @param[opt] UNSAFE
 ##   The homebrew uses private/system APIs and requires extended permissions
+## @param[opt] SECRETSAFE
+##   Generate a secret-safe eboot (vita-make-fself -ss) instead of a safe one.
+##   Do not use this if you don't know what it does. Takes priority over UNSAFE.
 ## @param[opt] STRIPPED
 ##   Strip the ELF while converting to Sony ELF format
 ## @param[opt] NOASLR
@@ -62,7 +66,7 @@ macro(vita_create_self target source)
   set(VITA_ELF_CREATE_FLAGS "${VITA_ELF_CREATE_FLAGS}" CACHE STRING "vita-elf-create flags")
   set(VITA_MAKE_FSELF_FLAGS "${VITA_MAKE_FSELF_FLAGS}" CACHE STRING "vita-make-fself flags")
 
-  set(options UNCOMPRESSED UNSAFE STRIPPED NOASLR REL_OPTIMIZE)
+  set(options UNCOMPRESSED UNSAFE SECRETSAFE STRIPPED NOASLR REL_OPTIMIZE)
   set(oneValueArgs CONFIG GEN_EXPORTS ATTRIBUTE MEMSIZE MODULE_ENTRY)
   cmake_parse_arguments(vita_create_self "${options}" "${oneValueArgs}" "" ${ARGN})
 
@@ -97,7 +101,9 @@ macro(vita_create_self target source)
   if(vita_create_self_MEMSIZE)
     set(VITA_MAKE_FSELF_FLAGS "${VITA_MAKE_FSELF_FLAGS} -m ${vita_create_self_MEMSIZE}")
   endif()
-  if(NOT vita_create_self_UNSAFE)
+  if(vita_create_self_SECRETSAFE)
+    set(VITA_MAKE_FSELF_FLAGS "${VITA_MAKE_FSELF_FLAGS} -ss")
+  elseif(NOT vita_create_self_UNSAFE)
     set(VITA_MAKE_FSELF_FLAGS "${VITA_MAKE_FSELF_FLAGS} -s")
   endif()
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -23,3 +23,7 @@ add_test(NAME test_make_fself
 add_test(NAME test_cmake_sourcepath
   COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test_cmake_sourcepath.py ${CMAKE_SOURCE_DIR}/cmake_toolchain/vita.cmake
 )
+
+add_test(NAME test_cmake_secretsafe
+  COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test_cmake_secretsafe.py ${CMAKE_SOURCE_DIR}/cmake_toolchain/vita.cmake
+)

--- a/test/fixtures/cmake_secretsafe/CMakeLists.txt
+++ b/test/fixtures/cmake_secretsafe/CMakeLists.txt
@@ -1,0 +1,27 @@
+cmake_minimum_required(VERSION 3.10)
+project(cmake_secretsafe_test C)
+
+# Stub tool paths: this project only configures (never builds), so the
+# custom-command lines just need to reference the right flags, not run.
+set(VITA_ELF_CREATE "echo")
+set(VITA_ELF_EXPORT "echo")
+set(VITA_LIBS_GEN "echo")
+set(VITA_LIBS_GEN_2 "echo")
+set(VITA_MAKE_FSELF "echo")
+set(VITA_PACK_VPK "echo")
+
+include(${VITA_CMAKE})
+
+# SELF_FLAG picks which vita_create_self option to exercise: this fixture is
+# configured fresh (one macro call per configure) once per flag combination,
+# since calling the macro more than once in the same project leaks flags
+# between calls (vitasdk/vita-toolchain#289) — unrelated to what's tested here.
+set(SELF_FLAG "" CACHE STRING "vita_create_self option under test")
+
+add_executable(mytarget dummy.c)
+
+if(SELF_FLAG STREQUAL "")
+  vita_create_self(mytarget.self mytarget)
+else()
+  vita_create_self(mytarget.self mytarget ${SELF_FLAG})
+endif()

--- a/test/fixtures/cmake_secretsafe/dummy.c
+++ b/test/fixtures/cmake_secretsafe/dummy.c
@@ -1,0 +1,1 @@
+int main(void) { return 0; }

--- a/test/test_cmake_secretsafe.py
+++ b/test/test_cmake_secretsafe.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+import sys
+import os
+import re
+import subprocess
+import tempfile
+
+def configure_and_get_command(vita_cmake, fixture_dir, self_flag, tmpdir):
+    build_dir = os.path.join(tmpdir, self_flag or "default")
+    res = subprocess.run([
+        "cmake", "-S", fixture_dir, "-B", build_dir,
+        f"-DVITA_CMAKE={vita_cmake}", f"-DSELF_FLAG={self_flag}", "-G", "Unix Makefiles"
+    ], capture_output=True, text=True)
+    if res.returncode != 0:
+        print(f"cmake configure failed (SELF_FLAG={self_flag}):", res.stderr)
+        sys.exit(1)
+
+    build_make = os.path.join(build_dir, "CMakeFiles", "mytarget.self-self.dir", "build.make")
+    with open(build_make) as f:
+        content = f.read()
+
+    m = re.search(r'^\techo (.*) \S+/mytarget\.velf \S+/mytarget\.self\.out$', content, re.MULTILINE)
+    assert m, f"Could not find the vita-make-fself command in {build_make}"
+    return m.group(1).split()
+
+def main():
+    if len(sys.argv) < 2:
+        print("Usage: test_cmake_secretsafe.py <path-to-vita.cmake>")
+        sys.exit(1)
+
+    vita_cmake = sys.argv[1]
+    fixture_dir = os.path.join(os.path.dirname(__file__), "fixtures", "cmake_secretsafe")
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        # Default: safe (-s), no secret-safe.
+        default_flags = configure_and_get_command(vita_cmake, fixture_dir, "", tmpdir)
+        assert "-s" in default_flags, f"Expected -s by default, got {default_flags}"
+        assert "-ss" not in default_flags, f"Did not expect -ss by default, got {default_flags}"
+
+        # UNSAFE: neither -s nor -ss.
+        unsafe_flags = configure_and_get_command(vita_cmake, fixture_dir, "UNSAFE", tmpdir)
+        assert "-s" not in unsafe_flags, f"UNSAFE should drop -s, got {unsafe_flags}"
+        assert "-ss" not in unsafe_flags, f"UNSAFE should not add -ss, got {unsafe_flags}"
+
+        # SECRETSAFE: -ss, and NOT the plain -s (#111).
+        secretsafe_flags = configure_and_get_command(vita_cmake, fixture_dir, "SECRETSAFE", tmpdir)
+        assert "-ss" in secretsafe_flags, f"Expected -ss with SECRETSAFE, got {secretsafe_flags}"
+        assert "-s" not in secretsafe_flags, f"SECRETSAFE should not also pass plain -s, got {secretsafe_flags}"
+
+    print("test_cmake_secretsafe: ALL TESTS PASSED")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
`vita-make-fself` has had a distinct `-ss` (secret-safe) flag alongside `-s` (safe) since early on, but `vita.cmake`'s `UNSAFE` toggle only ever wires up `-s` — there's never been a way to pass `-ss` from the CMake side. Adds a `SECRETSAFE` option that does that, taking priority over `UNSAFE` if both are given.

Tested with isolated single-call configures per flag combination (default / `UNSAFE` / `SECRETSAFE`), rather than multiple `vita_create_self` calls in one project — that trips #289 (flags leak between multiple calls to these macros in the same `CMakeLists.txt`), found while working on this. Filed separately rather than folded in here.

Closes #111